### PR TITLE
added export notice

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -158,3 +158,36 @@ page_classes: header-page
           Now you can learn how to extend your cloud platform (link), and automate
           some common tasks (link). Or browse our existing extensions to choose one
           which fits your needs (link).
+
+
+- if defined? deploy_type
+  %section#export.export-notice
+    .row
+      %section.col-md-12
+
+        :markdown
+          ## Export notice
+
+          By downloading ManageIQ software, you acknowledge that you
+          understand all of the following: ManageIQ software and
+          technical information may be subject to the U.S. Export
+          Administration Regulations (the “EAR”) and other U.S. and
+          foreign laws and may not be exported, re-exported or
+          transferred (a) to any country listed in Country Group E:1 in
+          Supplement No. 1 to part 740 of the EAR (currently, Cuba,
+          Iran, North Korea, Sudan &amp; Syria); (b) to any prohibited
+          destination or to any end user who has been prohibited from
+          participating in U.S. export transactions by any federal
+          agency of the U.S. government; or (c) for use in connection
+          with the design, development or production of nuclear,
+          chemical or biological weapons, or rocket systems, space
+          launch vehicles, or sounding rockets, or unmanned air vehicle
+          systems. You may not download ManageIQ software or technical
+          information if you are located in one of these countries or
+          otherwise subject to these restrictions. You may not provide
+          ManageIQ software or technical information to individuals or
+          entities located in one of these countries or otherwise
+          subject to these restrictions. You are also responsible for
+          compliance with foreign law requirements applicable to the
+          import, export and use of ManageIQ software and technical
+          information.

--- a/source/stylesheets/lib/site.sass
+++ b/source/stylesheets/lib/site.sass
@@ -636,3 +636,17 @@ q
 
 #discourse-comments
   margin: 2em 0 4em
+
+#export
+
+  .row
+    border-top: 1px solid #999
+    opacity: 0.6
+    padding-top: 0
+    margin-top: 3em
+
+  h2
+    font-size: 0.9em !important
+
+  p
+    font-size: 0.7em


### PR DESCRIPTION
Added a simple export notice, based on Fedora. All instances of Fedora have been changed to ManageIQ with a simple `s/Fedora/ManageIQ/g`

Style has been added to make it small at the bottom of the page, similar to Fedora's, except without the disclosure expander (which could be added if this is too intrusive).

This still needs legal approval for the text, or for Legal to send us proper text. As it's fairly boilerplate, it's probably eerily similar to this.
