### PR TITLE
added a link to edit the current page on github

### DIFF
--- a/data/site.yml
+++ b/data/site.yml
@@ -22,6 +22,10 @@ logo: logo.svg
 copyright: "&copy; 2014 ManageIQ. Sponsored by Red Hat, Inc."
 
 
+# Location where this repo exists on github
+github: ManageIQ/manageiq.org
+
+
 # Optional footer links
 #footer_links:
   #About: /about

--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -55,6 +55,12 @@
       .copyright
         = data.site.copyright || "&copy; #{year_string} #{data.site.owner || data.site.name}"
 
+      - if data.site.github
+        .edit-this-page
+          - source_file = current_page.source_file.sub(root, '')
+          - github_url = "https://github.com/#{data.site.github}/edit/master#{source_file}"
+          = link_to "Edit this page on GitHub", github_url
+
       .hosting-provider
         Hosting provided by
         = link_to "http://rackspace.com/" do

--- a/source/stylesheets/lib/site.sass
+++ b/source/stylesheets/lib/site.sass
@@ -607,15 +607,19 @@ q
   color: rgba(white, 0.8)
   padding: 1.5em
 
+  a
+    color: white
+
   section.footer-area
     text-align: center
 
   .copyright,
+  .edit-this-page,
   .hosting-provider
     //@extend .col-md-4
     font-size: 13px
     display: inline
-    padding: 0 1em
+    padding: 0 3em
 
   .copyright
     //@extend .col-md-offset-2


### PR DESCRIPTION
This edit-this-page link assumes three things:
1. User of GitHub is signed in to GitHub.
2. User of GitHub has access to view the repository.
3. User of GitHub has access to write to the repository.

If user is not signed in (point 1), then GitHub will display a sign in prompt.

If user does not have access to view the repository (point 2), a 404 will be displayed. (This will be fixed when the repository is made public.)

If user does not have access to write (point 3), I believe GitHub will fork the repo. This one needs testing by someone who has read-only access to the site.

…If all three conditions are met, then it “magically” displays an editing box with syntax highlighting for the page's source. (This even works for proxied pages, like the download area!)
