### PR TITLE
Disable AWS and expand RHEV as deployment platforms

### DIFF
--- a/data/deploy_types.yml
+++ b/data/deploy_types.yml
@@ -1,5 +1,4 @@
-amazon: Amazon EC2
 openstack: OpenStack
 ovirt: oVirt
-rhev: RHEV
+rhev: Red Hat Enterprise Virtualization
 vmware: VMware vSphere


### PR DESCRIPTION
We do not have AMIs for deployment on Amazon. Also, we should expand RHEV to its product name for the site.
