### PR TITLE
Update download links to use classes

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -60,8 +60,8 @@ page_classes: header-page
 
           - when 'ovirt'
             :markdown
-              [<i class="download-icon"></i>Download ManageIQ for oVirt](http://manageiq.org/downloads/ManageIQ-stable-ovirt.ova) to
-              your local computer.
+              [Download ManageIQ for oVirt](http://manageiq.org/downloads/ManageIQ-stable-ovirt.ova){: .download-link}
+              to your local computer.
 
               When the file has finished downloading, upload it to
               an export domain on your oVirt instance by running the
@@ -77,7 +77,7 @@ page_classes: header-page
 
           - when 'rhev'
             :markdown
-              [<i class="download-icon"></i>Download ManageIQ for Red Hat Enterprise Virtualization](http://manageiq.org/downloads/ManageIQ-stable-ovirt.ova)
+              [Download ManageIQ for Red Hat Enterprise Virtualization](http://manageiq.org/downloads/ManageIQ-stable-ovirt.ova){: .download-link}
               to your local computer.
 
               When the file has finished downloading, upload it to
@@ -109,8 +109,8 @@ page_classes: header-page
 
           - when 'vmware'
             :markdown
-              [<i class="download-icon"></i>Download ManageIQ for VMware vSphere](http://manageiq.org/downloads/ManageIQ-stable-vsphere.ova) to
-              your local computer.
+              [Download ManageIQ for VMware vSphere](http://manageiq.org/downloads/ManageIQ-stable-vsphere.ova){: .download-link}
+              to your local computer.
 
               In the vSphere Client, select File -> Deploy OVF Template.
               The Deploy OVF Template wizard appear, follow the
@@ -126,7 +126,7 @@ page_classes: header-page
           * Log into the ManageIQ dashboard by connecting to the new running VM
             with a web browser, or access the console of your virtual machine.
             The initial username and password is `admin`/`smartvm`.
-          
+
           * There are a number of basic settings, located under 
             "Configure -> Configuration" in the web interface, or under
             "Advanced setting" in the VM console, that you may wish to change 
@@ -137,9 +137,9 @@ page_classes: header-page
               * Hostname
               * Admin password
 
-          
 
-          
+
+
           ### Step 3: **Add an infrastructure or cloud provider**
 
           Now that you are up and running, you can connect your first
@@ -150,7 +150,7 @@ page_classes: header-page
           oVirt or vSphere), navigate to Infrastructure -> Providers.
           To add a new cloud provider (OpenStack, Amazon EC2), navigate
           to Clouds -> Providers.
-          
+
           Next, click the configuration icon (TODO: include icon here),
           and "+" to add a new provider.           
 
@@ -165,10 +165,10 @@ page_classes: header-page
           by clicking on the "radar" symbol (TODO: Include logo here). Check
           the provider type, provide a subnet range of IP addresses to search,
           and ManageIQ will prompt you to add new providers automatically.
-          
+
           Repeat the process above for the additional Cloud or Infrastructure 
           providers you wish to manage.
-          
+
           Consult the [quickstart guide](/documentation/quickstart) for more 
           detailed information on configuring providers,and on provisioning 
           virtual machines and cloud instances. 


### PR DESCRIPTION
Use download class for download icon, plus some trivial trailing whitespace fixes. Addresses issues in pull request #71 /cc @garrett 
