### PR TITLE
Remove link to github wiki

### DIFF
--- a/source/community/index.html.haml
+++ b/source/community/index.html.haml
@@ -32,7 +32,6 @@ title: Community
       ### Collaborate
       * [Report an issue](issues)
       * [Propose a feature in the forum](http://talk.manageiq.org)
-      * [Write cloud management tasks in the wiki](https://github.com/ManageIQ/manageiq/wiki)
 
   %section.col-md-4
     :markdown


### PR DESCRIPTION
We're intentionally leaving the github wiki disabled for the time being.  We
currently have ask.manageiq and talk.manageiq as well as the IRC channel.  It
would be better to have conversations and questions live in those places instead
of on the wiki.
