### PR TITLE
removed redundant configuration → discover

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -177,7 +177,7 @@ page_classes: header-page download-page
               For OpenStack, Amazon EC2
 
               1. Navigate to **Clouds** → **Providers**
-              2. Click **Configuration** → **Discover** or **Configuration** → **Discover**
+              2. Click **Configuration** → **Discover**
               3. Select the type
               4. Enter an IP Range
 


### PR DESCRIPTION
The download page listed the same **Configuration** → **Discover** part of the step twice.

Is this supposed to be something else?

Are the only difference between types selecting "Infrastructure" or "Cloud" at the top level?
