### PR TITLE
wrong username in path name

### DIFF
--- a/source/community/install-from-source.html.md
+++ b/source/community/install-from-source.html.md
@@ -97,7 +97,7 @@ Details on installing an image using a quickstart file are available from
     curl -sSL https://get.rvm.io | bash -s stable
     sudo rvm install 1.9.3
     gem install bundler -v '1.3.5'
-    gem uninstall -i /home/cfmebuilder/.rvm/gems/ruby-1.9.3-p547@global bundler -v '1.6.2'
+    gem uninstall -i /home/miqbuilder/.rvm/gems/ruby-1.9.3-p547@global bundler -v '1.6.2'
     ```
 
 9.  Clone the ManageIQ repo and install dependencies:


### PR DESCRIPTION
to uninstall bundler 1.6.2 from the home directory of miqbuilder the path name given has a wrong username.
