### PR TITLE
create database config file

### DIFF
--- a/source/community/install-from-source.html.md
+++ b/source/community/install-from-source.html.md
@@ -117,6 +117,7 @@ Details on installing an image using a quickstart file are available from
     `vmdb_development` database.
 
     ```
+    cp config/database.pg.yml config/database.yml
     bin/rake db:migrate
     bin/rake evm:start
     ```


### PR DESCRIPTION
there is no database.yml present in the directory by default. Added command to copy the sample file (database.pg.yml) create db config file.
