### PR TITLE
default username and password missing

### DIFF
--- a/source/community/install-from-source.html.md
+++ b/source/community/install-from-source.html.md
@@ -121,4 +121,4 @@ Details on installing an image using a quickstart file are available from
     bin/rake evm:start
     ```
 
-You should now be able to access the ManageIQ console at **\<IP_ADDRESS\>:3000**.
+You should now be able to access the ManageIQ console at **\<IP_ADDRESS\>:3000**. The default username and password is `username : admin` and `password : smartvm`


### PR DESCRIPTION
the default username and password to login to the web console is not present in this doc. Added to the end of doc.
