### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,9 @@ gem 'middleman-deploy'
 # Piwik tracker
 gem 'middleman-piwik'
 
+# Google Analytics
+gem 'middleman-google-analytics'
+
 # Thumbnailer
 #gem "middleman-thumbnailer", github: "nhemsley/middleman-thumbnailer"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
     middleman-favicon-maker (3.7)
       favicon_maker (~> 1.3)
       middleman-core (>= 3.0.0)
+    middleman-google-analytics (1.1.0)
+      middleman-core (~> 3.2)
+      uglifier (>= 2.1, < 3.0)
     middleman-livereload (3.3.4)
       em-websocket (~> 0.5.1)
       middleman-core (~> 3.2)
@@ -193,6 +196,7 @@ DEPENDENCIES
   middleman-blog
   middleman-deploy
   middleman-favicon-maker
+  middleman-google-analytics
   middleman-livereload
   middleman-piwik
   middleman-pry

--- a/config.rb
+++ b/config.rb
@@ -192,6 +192,9 @@ activate :piwik do |f|
     f.domain = 'analytics.manageiq.org'
 end
 
+activate :google_analytics do |ga|
+  ga.tracking_id = 'UA-58883457-1'
+end
 
 ###
 # Monkey patches

--- a/source/layouts/_production_only.haml
+++ b/source/layouts/_production_only.haml
@@ -6,3 +6,6 @@
 
 / piwik
 ~ insert_piwik_tracker
+
+/ Google Analytics
+= google_analytics_tag


### PR DESCRIPTION
Add tracking code for Google Analytics.

Tracking is important to start measuring the efforts of various community marketing efforts we are planning.

The tracking code refers to a GA account under gjansen@redhat.com. I have the ability to add any Gmail or Google Apps account.

If it's more appropriate, I'm also happy to transfer the GA account to John Mark as the community manager.