### PR TITLE
g++ is prerequisite for installing eventmachine gem

### DIFF
--- a/source/community/install-from-source.html.md
+++ b/source/community/install-from-source.html.md
@@ -42,7 +42,7 @@ Details on installing an image using a quickstart file are available from
 
     ```bash
     yum -y install git libxml2-devel libxslt libxslt-devel sudo
-    yum -y install postgresql-server postgresql-devel memcached ruby-devel
+    yum -y install postgresql-server postgresql-devel memcached ruby-devel gcc-c++
     ```
 
 6.  Start memcached


### PR DESCRIPTION
Without g++ installed, i got this error during `bundle install` command:

    make "DESTDIR="
    compiling kb.cpp
    `make: g++: Command not found`
    Makefile:215: recipe for target 'kb.o' failed
    make: *** [kb.o] Error 127
    ...

    An error occurred while installing eventmachine (1.0.6), and Bundler cannot
    continue.
    Make sure that `gem install eventmachine -v '1.0.6'` succeeds before bundling