### PR TITLE
fixed an incorrect link for feature suggestions (404 on talk)

### DIFF
--- a/source/community/index.html.haml
+++ b/source/community/index.html.haml
@@ -29,7 +29,7 @@ title: Community
     :markdown
       ### Collaborate
       * [Report an issue](issues)
-      * [Propose a feature in the forum](http://talk.manageiq.org/category/blueprints)
+      * [Propose a feature in the forum](http://talk.manageiq.org/c/developers/blueprints)
       * [View the ManageIQ Roadmap on Trello](https://trello.com/b/UeTqKlp3/manageiq-roadmap)
       
   %section.col-md-4


### PR DESCRIPTION
Perhaps talk.manageiq.org changed URLs?