### PR TITLE
Fixed markdown on 'Install from source' page

### DIFF
--- a/source/community/install-from-source.html.md
+++ b/source/community/install-from-source.html.md
@@ -143,7 +143,7 @@ You should now be able to access the ManageIQ console at **\<IP_ADDRESS\>:3000**
 
 * Configure memcached
 
- ```bash
+  ```bash
   $ mkdir ~/Library/LaunchAgents
   $ cp /usr/local/Cellar/memcached/$version/homebrew.mxcl.memcached.plist ~/Library/LaunchAgents/
   $ launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.memcached.plist.
@@ -201,11 +201,13 @@ You should now be able to access the ManageIQ console at **\<IP_ADDRESS\>:3000**
 ## Install Ruby
 
 * RVM: <http://rvm.io/>
+
   ```bash
   $ \curl -L https://get.rvm.io | bash -s stable —ruby
   ```
   
 * RUBY:
+
   ```bash  
   $ rvm install ruby-2.0.0
   $ rvm --default use ruby-2.0.0


### PR DESCRIPTION
Fixed markdown that was causing wrong highlighting on '[Install from source](http://manageiq.org/community/install-from-source/)' page.

Example:

![screenshot-manageiq org 2015-07-11 15-39-02](https://cloud.githubusercontent.com/assets/1187051/8633909/275d4e86-27e3-11e5-935c-09ab6dc8a6ec.png)
