### PR TITLE
as more partners were added since the founding, s/partners//

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -172,7 +172,7 @@ blog_summary_length: 700
 
     %section.col-md-12
 
-      %h2 Founding Community Partners
+      %h2 Community Partners
 
       %ul.partners
         - partners.each do |partner, val|


### PR DESCRIPTION
The website lists more partners than the original founders, hence this removal.