### PR TITLE
Fix VM pages illustration key

### DIFF
--- a/source/documentation/getting-started.html.md
+++ b/source/documentation/getting-started.html.md
@@ -568,6 +568,7 @@ The **Virtual Machines** pages display all virtual machines that were discovered
 
 ![](doc/getting-started/2124.png)
 
+{:type="lower-alpha"}
 1.  History button
 2.  Refresh screen button
 3.  Taskbar


### PR DESCRIPTION
The illustration is labelled a-j, but the key is 1-10. This change makes
the key use the same type (lower alpha).