### PR TITLE
Don't leave dangling processes

### DIFF
--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -78,8 +78,8 @@
           = image_tag "/images/partners/rackspace-on-dark.svg", alt: "Rackspace"
 
       .last-modified
-        - modified_time = IO.popen(['git', 'log', '--pretty=format:%ai', current_page.source_file]).read.split(/\n/).first rescue nil
+        - modified_time = IO.popen(%W(git log --pretty=format:%ai --max-count=1 #{current_page.source_file}), &:read) rescue nil
 
-        - if modified_time
+        - if modified_time && !modified_time.empty?
           Page last modified
           = Time.parse(modified_time).utc.strftime('%a %-d %b %Y %H:%M %Z')


### PR DESCRIPTION
Fixes #229, without introducing a shell injection.

In passing, don't bother searching the complete history of the file when we just want to know one date.