### PR TITLE
Include submodules in clone command (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Step 1: Check it out
 
 Check out this this git repository by running:
-`git clone git@github.com:ManageIQ/manageiq.org.git`
+`git clone --recursive git@github.com:ManageIQ/manageiq.org.git`
 
 When the git clone is done, run `cd manageiq.org` to change to the
 checked out directory.


### PR DESCRIPTION
I'm not entirely familiar but I believe the submodules included in this project are intended to be cloned to run it locally. This changes the command given to include `--recursive` to clone the guides and remove errors such as this one when following the steps outlined in README:

```
middleman-core/sitemap/extensions/proxies.rb:46:in `proxied_to_resource': Path documentation/development/index.html proxies to unknown file documentation/development/README.html:[] (RuntimeError)
```