### PR TITLE
Add summit teaser on main page + update CFP description and extension

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -15,6 +15,12 @@ page_classes: front-page header-page
       %h2 Control All the Things 
       %h3 automate, optimize, and control your cloud and virtualization services
 
+%section.summit-teaser
+  .row
+    %section.col-md-12.center
+      %a{title: "ManageIQ Design Summit 2016", href: "/summit/"}
+        %img{src:"/images/manageiq-summit-logo.svg", width:400}
+
 - if (teaser_article = blog.articles.find(&:published?))
   %section.blog-teaser
     .row

--- a/source/stylesheets/lib/site.sass
+++ b/source/stylesheets/lib/site.sass
@@ -304,6 +304,15 @@ pre, code
     color: #888
     font-size: 80%
 
+.summit-teaser
+  background: $bg-header-color
+  border-bottom: 1px solid rgba(0,0,0,0.25)
+
+  .row
+    border-top: none !important
+    padding-top: 8px !important
+    padding-bottom: 8px !important
+    
 body.front-page
 
   .page-header

--- a/source/summit/index.html.haml
+++ b/source/summit/index.html.haml
@@ -60,16 +60,20 @@ page_classes: summit-page header-page
         ## Program
 
         The summit presents an excellent opportunity to engage with your fellow
-        community members. Perhaps on how adopting ManageIQ has streamlined your
-        project’s workflow, the different integration efforts and use-cases,
-        proposing new feature implementations, or maybe even some challenges
-        faced and lessons-learned.
+        community members, developers, and stakeholders. Here are some suggestions
+        for presentation topics, and you are welcome to submit other topics
+        related to ManageIQ as well.
+        
+        * integration: deploying ManageIQ with various tools and platforms
+        * proposing new features to be implemented in the ManageIQ project
+        * demos: showcase scenarios exemplifying ManageIQ’s features and capabilities
+        * user stories: achievements and challenges with ManageIQ
 
         Call for papers is now open, please check the details and submit your
         talk proposals at [PaperCall](https://www.papercall.io/miqsummit2016)
         (convenient login with your Github, Twitter, Google or Facebook accounts).
 
-        Deadline for submission: **March 31, 2016**
+        Deadline for submission: **April 8, 2016**
 
         Acceptance and agenda will be announced in mid-April.
 


### PR DESCRIPTION
Changes:

1. adding a visible summit link for visitors to the front page of manageiq.org
2. updating the Program/CFP section to give a better idea of possible topics
3. extending the CFP deadline by a week based on feedback/discussions