### PR TITLE
Fix malformed yaml.

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -310,7 +310,7 @@ Garrett LeSage:
   googleplus: GarrettLeSage
   gravatar: ee31aa48c51297eb062133b15eaff702
 
-Šimon Lukašík
+Šimon Lukašík:
   bio: Software engineer. I work, eat, sleep, get up and do it all over again. I read books when left unattended. I enjoy watching bad theater and removing code that reminds it.
   github: isimluk
   twitter: isimluk


### PR DESCRIPTION
And the travis failure.

/home/travis/.rvm/rubies/ruby-2.0.0-p598/lib/ruby/2.0.0/psych.rb:205:in `parse': (/home/travis/build/ManageIQ/manageiq.org/data/team.yml): could not find expected ':' while scanning a simple key at line 313 column 1 (Psych::SyntaxError)