### PR TITLE
Add agenda to ManageIQ design summit page

### DIFF
--- a/source/stylesheets/lib/site.sass
+++ b/source/stylesheets/lib/site.sass
@@ -336,6 +336,18 @@ body.front-page
 
 body.summit-page
 
+  table
+    width: 100%
+  th
+    background: whitesmoke
+  th, td
+    border: 1px solid
+    padding: 5px
+    text-align: center
+  .summit-talk
+    background: snow
+    padding: 12px
+
   .page-header
     background: $bg-header-color url(/images/header-clouds.jpg) no-repeat fixed left bottom
     background-size: cover

--- a/source/summit/index.html.haml
+++ b/source/summit/index.html.haml
@@ -59,23 +59,114 @@ page_classes: summit-page header-page
     
         ## Program
 
-        The summit presents an excellent opportunity to engage with your fellow
-        community members, developers, and stakeholders. Here are some suggestions
-        for presentation topics, and you are welcome to submit other topics
-        related to ManageIQ as well.
-        
-        * integration: deploying ManageIQ with various tools and platforms
-        * proposing new features to be implemented in the ManageIQ project
-        * demos: showcase scenarios exemplifying ManageIQ’s features and capabilities
-        * user stories: achievements and challenges with ManageIQ
+        Thanks to all of you who have submitted talk proposals at
+        [PaperCall](https://www.papercall.io/miqsummit2016). We have received many
+        excellent presentation topics. Here's the agenda for the 2 conference
+        days (subject to change):
 
-        Call for papers is now open, please check the details and submit your
-        talk proposals at [PaperCall](https://www.papercall.io/miqsummit2016)
-        (convenient login with your Github, Twitter, Google or Facebook accounts).
+      %table
+        %tr
+          %th{width: "10%"} June 6
+          %th{width: "45%"} Track 1
+          %th Track 2
+        %tr
+          %td 8:30
+          %td{colspan: 2} Breakfast
+        %tr
+          %td 9:00
+          %td.summit-talk{colspan: 2} ManageIQ Design Summit Keynote (Oleg Barenboim)
+        %tr
+          %td 9:45
+          %td.summit-talk{colspan: 2} ManageIQ, now harnessing the power of Google's infrastructure! (Eric Johnson)
+        %tr
+          %td 10:30
+          %td{colspan: 2} Break
+        %tr
+          %td 11:00
+          %td.summit-talk{colspan: 2} Cloud Networking (Nuage, Greg Blomquist, Jason Frey)
+        %tr
+          %td 11:45
+          %td.summit-talk{colspan: 2} MIQ Code Management and Promotion with special guests Ansible and Git (Jason Cornell)
+        %tr
+          %td 12:30
+          %td{colspan: 2} Lunch
+        %tr
+          %td 13:30
+          %td.summit-talk ManageIQ High Availability (Brett Thurber)
+          %td.summit-talk DevOps with ManageIQ and OpenShift (Fabian Dupont)
+        %tr
+          %td 14:15
+          %td.summit-talk Replication (Nick Carboni) and Authentication (Alberto Bellotti)
+          %td.summit-talk Self-Service UI (Dan Clarizio, Greg McCullough)
+        %tr
+          %td 15:00
+          %td{colspan: 2} Break
+        %tr
+          %td 15:30
+          %td.summit-talk ManageIQ for VMware vSphere (Adam Grare, Greg Blomquist)
+          %td.summit-talk ManageIQ for Azure (Bronagh Sorota)
+        %tr
+          %td 16:15
+          %td.summit-talk Community Update and Discussion (Oleg Barenboim, Carol Chen)
+          %td.summit-talk Working to design the new chargeback interface (Sergio Ocon)
+        %tr
+          %td 17:00
+          %td{colspan: 2} Day 1 wrap-up
+        %tr
+          %td 17:30
+          %td{colspan: 2} Evening social
 
-        Deadline for submission: **April 8, 2016**
+      %br
+      %br
 
-        Acceptance and agenda will be announced in mid-April.
+      %table
+        %tr
+          %th{width: "10%"} June 7
+          %th{width: "45%"} Track 1
+          %th Track 2
+        %tr
+          %td 8:30
+          %td{colspan: 2} Breakfast
+        %tr
+          %td 9:00
+          %td.summit-talk{colspan: 2} ManageIQ UI Improvements (Dan Clarizio, Eric Winchell)
+        %tr
+          %td 9:45
+          %td.summit-talk{colspan: 2} Container Management in ManageIQ: One Year in Review (Federico Simoncelli)
+        %tr
+          %td 10:30
+          %td{colspan: 2} Break
+        %tr
+          %td 11:00
+          %td.summit-talk{colspan: 2} Pluggable Providers (John Hardy, Jason Frey, Greg Blomquist, Marcel Hild)
+        %tr
+          %td 11:45
+          %td.summit-talk{colspan: 2} Automate and Generic Objects (Madhu Kanoor, Greg McCullough)
+        %tr
+          %td 12:30
+          %td{colspan: 2} Lunch
+        %tr
+          %td 13:30
+          %td.summit-talk Implementation in a Managed Service Environment (Mike Hulsman)
+          %td.summit-talk Investigative Debugging of ManageIQ Automation (Peter McGowan)
+        %tr
+          %td 14:15
+          %td.summit-talk ManageIQ for OpenStack (Loic Avenel)
+          %td.summit-talk ManageIQ and Ansible (Greg McCullough, Drew Bomhof, Brandon Dunne)
+        %tr
+          %td 15:00
+          %td{colspan: 2} Break
+        %tr
+          %td 15:30
+          %td.summit-talk Integration with oVirt 4 (Juan Hernandez)
+          %td.summit-talk Including Middleware in the Game (Heiko Rupp)
+        %tr
+          %td 16:15
+          %td.summit-talk OpenNMS as complement to ManageIQ (Jeff Gehlbach)
+          %td.summit-talk Getting your First Pull Request Merged (Sergio Ocon)
+        %tr
+          %td 17:00
+          %td{colspan: 2} Event wrap-up
 
   .row
     %section.col-md-12


### PR DESCRIPTION
Update the Program section of the summit page: remove info about CFP that has ended, and add the 2-day event agenda.