### PR TITLE
adding tags for responsive images

### DIFF
--- a/site/docs/get-started/add-a-provider.md
+++ b/site/docs/get-started/add-a-provider.md
@@ -32,7 +32,7 @@ tutorial on the platform.
 3.  Create an instance or follow the tutorial. For instance, a CentOS 7
     VM with 10 GB hard drive
 
-![screenshot0007](/assets/images/docs/screenshot_0007.png)
+![screenshot0007](/assets/images/docs/screenshot_0007.png){:.img-responsive}
 
 After you finish the tutorial, you should have at least 1 instance in your account
 
@@ -52,26 +52,26 @@ Platform (API → Credentials), don’t forget your key as you will
     need it. And enable API for the
     project (https://support.google.com/cloud/answer/6158841)
 
-![screenshot0008](/assets/images/docs/screenshot_0008.png)
+![screenshot0008](/assets/images/docs/screenshot_0008.png){:.img-responsive}
 
 #### 3.  Add a new Cloud provider ####
 In ManageIQ, go to ***Compute→Cloud → Providers*** and select Add New
     Cloud Provider.
 
-![screenshot0009](/assets/images/docs/screenshot_0009.png)
+![screenshot0009](/assets/images/docs/screenshot_0009.png){:.img-responsive}
 
 #### 4. Select Google Cloud Platform ####
 
 Select Google Cloud Platform as type
 
-![screenshot0010](/assets/images/docs/screenshot_0010.png)
+![screenshot0010](/assets/images/docs/screenshot_0010.png){:.img-responsive}
 
 #### 5. Enter credentials ####
 Enter your Google Compute Engine Project ID for *Project*.
 Copy your project’s *Service Account* JSON key contents to the
     *Service Account JSON* field.
 
-![screenshot0011](/assets/images/docs/screenshot_0011.png)
+![screenshot0011](/assets/images/docs/screenshot_0011.png){:.img-responsive}
 
 #### 6. Store the provider configuration  ####
  Press ***Validate*** and then ***Add***
@@ -86,6 +86,6 @@ Copy your project’s *Service Account* JSON key contents to the
     the Provider and then press *Authentication → Re-check
     Authentication Status* to trigger a refreshment.
 
-![screenshot0012](/assets/images/docs/screenshot_0012.png)
+![screenshot0012](/assets/images/docs/screenshot_0012.png){:.img-responsive}
 
 ## Next: [Review Provider](/docs/get-started/review-provider)

--- a/site/docs/get-started/basic-configuration.md
+++ b/site/docs/get-started/basic-configuration.md
@@ -18,7 +18,7 @@ setting ssh keys)
     1.  **Docker:** localhost (127.0.0.1)
     2.  **Vagrant:** 172.28.128.3
 
-![screenshot0001](/assets/images/docs/screenshot_0001.png)
+![screenshot0001](/assets/images/docs/screenshot_0001.png){:.img-responsive}
 
 ### 2. Log in using default credentials
 
@@ -31,7 +31,7 @@ The main menus are available in
     expanded when needed. You can pin a secondary or tertiary menu to
     easily navigate through its elements.
 
-![screenshot0002](/assets/images/docs/screenshot_0002.png)
+![screenshot0002](/assets/images/docs/screenshot_0002.png){:.img-responsive}
 
 ###  4. Change options
 Go to Settings → Configuration to change how the appliance behaves:
@@ -48,7 +48,7 @@ Go to Settings → Configuration to change how the appliance behaves:
 -         ***Select your time zone***, and, 
         if you want, you can change the language default.
 
-![screenshot0003](/assets/images/docs/screenshot_0003.png)
+![screenshot0003](/assets/images/docs/screenshot_0003.png){:.img-responsive}
 
 #### 2. Choose functions for this appliance ####
 Server control defines what roles each appliance executes in a
@@ -57,11 +57,11 @@ Server control defines what roles each appliance executes in a
         Database synchronization, Git Repositories Owner, RHN Mirror or
         Smart Proxy unless you need them.
 
-![screenshot0004](/assets/images/docs/screenshot_0004.png)
+![screenshot0004](/assets/images/docs/screenshot_0004.png){:.img-responsive}
 
 #### 3.  Configure your email server so ManageIQ can send you emails ####
 
-![screenshot0005](/assets/images/docs/screenshot_0005.png)
+![screenshot0005](/assets/images/docs/screenshot_0005.png){:.img-responsive}
 
 #### 4. Save your changes ####
 **Press Save*** to save your changes
@@ -77,6 +77,6 @@ In the accordion, ***select Access Control.***
 3.    Click ***Configuration → Add a new User*** 
 4.    Fill all the elements in the form (***select Role *EvmRole-user\_limited\_self\_service****) and then ***press *Add***
 
-![screenshot0005](/assets/images/docs/screenshot_0006.png)
+![screenshot0005](/assets/images/docs/screenshot_0006.png){:.img-responsive}
 
 ## Next: [Add A Provider](/docs/get-started/add-a-provider)

--- a/site/docs/get-started/cloud.md
+++ b/site/docs/get-started/cloud.md
@@ -10,17 +10,17 @@ The installation of ManageIQ consists on two phases:
 
 We will use the Google Cloud Platform as an example, so you need to open an account. Free accounts can be opened in [Google Cloud](https://console.cloud.google.com/freetrial) for eligible users.
 
-![screenshot0037](/assets/images/docs/screenshot_0037.png)
+![screenshot0037](/assets/images/docs/screenshot_0037.png){:.img-responsive}
 
 ## 1. Installing ManageIQ as a cloud image ##
 ### Step 1. Create a new image ###
 From console.cloud.google.com, go to "Compute Engine" and then "Images"
 
-![screenshot0038](/assets/images/docs/screenshot_0038.png)
+![screenshot0038](/assets/images/docs/screenshot_0038.png){:.img-responsive}
 
 Create a new image:
 
-![screenshot0040](/assets/images/docs/screenshot_0040.png)
+![screenshot0040](/assets/images/docs/screenshot_0040.png){:.img-responsive}
 
 **Name:** manageiq-darga-3
 
@@ -34,7 +34,7 @@ Create a new image:
 
 Once the image is created, you can create a new instance based on this
 image. It's recommended to select the 2 CPU / 7.5GB instance.
-![screenshot0041](/assets/images/docs/screenshot_0041.png)
+![screenshot0041](/assets/images/docs/screenshot_0041.png){:.img-responsive}
 
 While creating the image, select in firewalls:
 ~~~~
@@ -42,7 +42,7 @@ While creating the image, select in firewalls:
 -[x] Allow HTTPS traffic
 ~~~~
 
-![screenshot0042](/assets/images/docs/screenshot_0042.png)
+![screenshot0042](/assets/images/docs/screenshot_0042.png){:.img-responsive}
 
 ```
 #### [NOTE]

--- a/site/docs/get-started/provision-machine.md
+++ b/site/docs/get-started/provision-machine.md
@@ -19,21 +19,21 @@ will be available at the same time and you will be able to interact with them.
 
 Select ***Lifecycle → Provision Instances*** from the bar on the top.
 
-![screenshot0027](/assets/images/docs/screenshot_0027.png) 
+![screenshot0027](/assets/images/docs/screenshot_0027.png){:.img-responsive}
 
 After a few seconds you will have a list of all images available, select
 *the latest version of centos-7*. Press ***Continue***
 
 There are different elements that you need to fulfill:
 
-![screenshot0028](/assets/images/docs/screenshot_0028.png) 
+![screenshot0028](/assets/images/docs/screenshot_0028.png){:.img-responsive}
 
 #### Request####
 
 The information about the request itself, it will be used for reporting,
 notifications, and to help decide whether approve it or not.
 
-![screenshot0029](/assets/images/docs/screenshot_0029.png) 
+![screenshot0029](/assets/images/docs/screenshot_0029.png){:.img-responsive} 
 
 #### Purpose####
 
@@ -47,7 +47,7 @@ about this in the documentation.
 This will allow to modify some characteristics of the instance, like the
 number of instances, its name and description.
 
-![screenshot0030](/assets/images/docs/screenshot_0030.png) 
+![screenshot0030](/assets/images/docs/screenshot_0030.png){:.img-responsive} 
 
 #### Environment####
 
@@ -57,7 +57,7 @@ network to be used.
 You can always check ***choose automatically*** to allow the system to find
 the best option for you.
 
-![screenshot0031](/assets/images/docs/screenshot_0031.png) 
+![screenshot0031](/assets/images/docs/screenshot_0031.png){:.img-responsive} 
 
 #### Properties #####
 
@@ -66,13 +66,13 @@ it to your necessities.
 
 Choose a small instance type: (*g1-small*) and a boot-disk of *10 GB*.
 
-![screenshot0032](/assets/images/docs/screenshot_0032.png) 
+![screenshot0032](/assets/images/docs/screenshot_0032.png){:.img-responsive} 
 
 #### Schedule #####
 
 This allows you to decide if you want to provision the Instance now or in a later time.
 
-![screenshot0033](/assets/images/docs/screenshot_0033.png) 
+![screenshot0033](/assets/images/docs/screenshot_0033.png){:.img-responsive} 
 
 Press ***Submit***
 
@@ -80,12 +80,12 @@ You will see your request go through different stages (you can press
 ***Reload*** to see the changes)
 
 
-![screenshot0034](/assets/images/docs/screenshot_0034.png) 
+![screenshot0034](/assets/images/docs/screenshot_0034.png){:.img-responsive}
 
 After a few seconds, a new vm will be present, owner and group will be
 properly set up for this new VM and you will see all the information about it.
 
-![screenshot0035](/assets/images/docs/screenshot_0035.png) 
+![screenshot0035](/assets/images/docs/screenshot_0035.png){:.img-responsive} 
 
 
 Once you have this VM created, you can go to any of the VM and choose
@@ -93,6 +93,6 @@ Once you have this VM created, you can go to any of the VM and choose
 charges
 
 
-![screenshot0036](/assets/images/docs/screenshot_0036.png) 
+![screenshot0036](/assets/images/docs/screenshot_0036.png){:.img-responsive} 
 
 ## Next: [Create a Self-service Catalog Item](/docs/get-started/create-service-item)

--- a/site/docs/get-started/review-provider.md
+++ b/site/docs/get-started/review-provider.md
@@ -8,7 +8,7 @@ Go to ***Compute → Clouds → Providers***
 
 You can see there your new GCE provider, and a quad icon with four zones that specifies:
 
-![screenshot0013a](/assets/images/docs/screenshot_0013a.png) 
+![screenshot0013a](/assets/images/docs/screenshot_0013a.png){:.img-responsive}
 
 - Type of provider
 - Authentication status
@@ -24,7 +24,7 @@ discovered:
 -   Number of instances (VM)
 -   Number of Images (Templates)
 
-![screenshot0013](/assets/images/docs/screenshot_0013.png)
+![screenshot0013](/assets/images/docs/screenshot_0013.png){:.img-responsive}
 
 
 Clicking it will show you more information:
@@ -33,17 +33,17 @@ Clicking it will show you more information:
     like type of provider and preferred region. This information will be
     different for each provider.
 
-![screenshot0019](/assets/images/docs/screenshot_0019.png) 
+![screenshot0019](/assets/images/docs/screenshot_0019.png){:.img-responsive} 
 -   **Status**. Whether your credentials are valid and when the last refresh
     was done.
 
-![screenshot0015](/assets/images/docs/screenshot_0015.png) 
+![screenshot0015](/assets/images/docs/screenshot_0015.png){:.img-responsive} 
 -   **Relationships**. Including the information about the components of the
     provider, like the number of security groups defined in the network,
     the number of available flavors (virtual hardware characteristics),
     cloud volumes, etc.
 
-![screenshot0018](/assets/images/docs/screenshot_0018.png) 
+![screenshot0018](/assets/images/docs/screenshot_0018.png){:.img-responsive} 
 
 
 
@@ -51,7 +51,7 @@ You can click on any of those elements to see detail information and a
 list of objects within. For instance, you can click on ***Instances*** to
 see names and characteristics of the instances within the provider
 
-![screenshot0014](/assets/images/docs/screenshot_0014.png) 
+![screenshot0014](/assets/images/docs/screenshot_0014.png){:.img-responsive} 
 
 ## Discovering a VM
 
@@ -61,11 +61,11 @@ don’t see any to create a new VM).
 You will find in the accordion a hierarchy tree that allows you to see
 the context: our machine is part of the avaiability zone: *“us-east1-b”*.
 
-![screenshot0021a](/assets/images/docs/screenshot_0021a.png)
+![screenshot0021a](/assets/images/docs/screenshot_0021a.png){:.img-responsive}
 
 There is a lot of detailed information out of the box:
 
-![screenshot0016](/assets/images/docs/screenshot_0016.png)
+![screenshot0016](/assets/images/docs/screenshot_0016.png){:.img-responsive}
 
 ### Information available ###
 
@@ -75,7 +75,7 @@ ManageIQ is capable of autodiscovering all IP addresses associated to
 the VM, the container (hardware associated to the instance), or the
 Operating System that is using, automatically.
 
-![screenshot0023](/assets/images/docs/screenshot_0023.png)
+![screenshot0023](/assets/images/docs/screenshot_0023.png){:.img-responsive}
 
 
 #### Lifecycle####
@@ -84,7 +84,7 @@ It provides information about the lifecycle of the entity, when it was
 discovered, and when it was last analyzed. Whether there is a retirement
 date for the instance, and the group it belongs to.
 
-![screenshot0025](/assets/images/docs/screenshot_0025.png)
+![screenshot0025](/assets/images/docs/screenshot_0025.png){:.img-responsive}
 
 #### Relationships####
 
@@ -100,7 +100,7 @@ As different cloud providers use different concepts, it is possible that
 you find many parameters define as 0 or None. You need to check in the
 documentation what information is discovered for each one.
 
-![screenshot0018](/assets/images/docs/screenshot_0018.png) 
+![screenshot0018](/assets/images/docs/screenshot_0018.png){:.img-responsive} 
 
 #### Compliance####
 
@@ -113,7 +113,7 @@ Allows you to know the power state of the instance and the last time
 ManageIQ saw it changing. As these instances are discovered, ManageIQ
 does not know the last time it booted.
 
-![screenshot0026](/assets/images/docs/screenshot_0026.png)
+![screenshot0026](/assets/images/docs/screenshot_0026.png){:.img-responsive}
 
 
 #### Security, Configuration, Diagnostics and Smart Management####
@@ -121,7 +121,7 @@ does not know the last time it booted.
 More advanced capabilities are available for selected providers,
 including agentless inspection of workloads to discover
 
-![screenshot0017](/assets/images/docs/screenshot_0017.png) 
+![screenshot0017](/assets/images/docs/screenshot_0017.png){:.img-responsive}
 
 ## Reporting##
 


### PR DESCRIPTION
Adding {:.img-responsive} at the end of images tag them as responsive, allowing the documentation to be seen in any size of screen.