### PR TITLE
Link to API docs from documentation overview page

### DIFF
--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -14,9 +14,9 @@ Get a more in-depth look at the usage of ManageIQ, with installation instruction
 
 ## [ManageIQ Automation Book](automation)
 
-The Automate feature in ManageIQ is a huge topic in itself, so [Peter McGowan](https://github.com/pemcg) wrote a book on it. This tutorial style book will guide you through the steps of doing something in automate, with a lot of code samples. 
+The Automate feature in ManageIQ is a huge topic in itself, so [Peter McGowan](https://github.com/pemcg) wrote a book on it. This tutorial style book will guide you through the steps of doing something in automate, with a lot of code samples.
 
-## API Reference
+## [API Docs](reference/latest/api/overview/auth/)
 
 This guide provides web services available to integrate ManageIQ with external applications. It details the specification of the ManageIQ RESTful API, which is implemented as standard REST HTTP requests and responses of content type JSON.
 


### PR DESCRIPTION
Adds a missing link to API docs