### PR TITLE
Fix API Docs link

### DIFF
--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -16,7 +16,7 @@ Get a more in-depth look at the usage of ManageIQ, with installation instruction
 
 The Automate feature in ManageIQ is a huge topic in itself, so [Peter McGowan](https://github.com/pemcg) wrote a book on it. This tutorial style book will guide you through the steps of doing something in automate, with a lot of code samples.
 
-## [API Docs](reference/latest/api/overview/auth/)
+## [API Docs](reference/latest/api/overview/auth.html)
 
 This guide provides web services available to integrate ManageIQ with external applications. It details the specification of the ManageIQ RESTful API, which is implemented as standard REST HTTP requests and responses of content type JSON.
 


### PR DESCRIPTION
Use the .html url for now.