### PR TITLE
Prefix page title with site title.

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+  <title>{{ site.title | escape }}{% if page.title %} - {{ page.title | escape }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   {% css main %}


### PR DESCRIPTION
Page titles are now like "ManageIQ - Get Started". It results in nicer
summaries in Google search results.