### PR TITLE
Be consistent with trailing slashes.

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -62,6 +62,7 @@ defaults:
       type: pages
     values:
       layout: doc_page
+      permalink: /:path/:basename
       doc_group: start
   - scope:
       path: "docs/guides"

--- a/site/_data/menus/start_menu.yml
+++ b/site/_data/menus/start_menu.yml
@@ -1,15 +1,15 @@
 ---
 - title: Get started
-  path: /docs/get-started
+  path: /docs/get-started/
 
 - title: Get ManageIQ
   children:
     - title: Vagrant
-      path: /docs/get-started/vagrant/
+      path: /docs/get-started/vagrant
     - title: Docker
-      path: /docs/get-started/docker/
+      path: /docs/get-started/docker
     - title: Public Cloud
-      path: /docs/get-started/cloud/
+      path: /docs/get-started/cloud
 
 - title: Configuration
   path: /docs/get-started/basic-configuration
@@ -26,9 +26,8 @@
 - title: Create Your First Service Item
   path: /docs/get-started/create-service-item
 
-
 - title: Where to go from here
   path: /docs/get-started/where-to-go-from-here
 
 - title: Concepts Guide
-  path: /docs/concepts
+  path: /docs/get-started/concepts

--- a/site/_includes/docs/top_menu_items.html
+++ b/site/_includes/docs/top_menu_items.html
@@ -5,8 +5,8 @@
   <li{% if include.active == "user" %} class="active"{% endif %}>
     <a href="/docs/reference/">User Reference</a>
   </li>
-  <li{% if page.url == "/docs/automation/" %} class="active"{% endif %}>
-    <a href="/docs/automation/">
+  <li{% if page.url == "/docs/automation" %} class="active"{% endif %}>
+    <a href="/docs/automation">
       Automation Book
     </a>
   </li>

--- a/site/docs/automation.md
+++ b/site/docs/automation.md
@@ -1,7 +1,7 @@
 ---
 layout: doc_page
 title: Automation Book
-permalink: /docs/automation/
+permalink: /docs/automation
 ---
 
 ## [Mastering Automation in ManageIQ]({{ site.book_path }})

--- a/site/docs/get-started/concepts.md
+++ b/site/docs/get-started/concepts.md
@@ -1,7 +1,6 @@
 ---
 layout: doc_page
 title: Concepts guide
-permalink: /docs/concepts/
 ---
 
 ## Concepts

--- a/site/docs/get-started/index.md
+++ b/site/docs/get-started/index.md
@@ -1,8 +1,6 @@
 ---
 layout: doc_page
 title: Get Started
-permalink: /docs/get-started/
-doc_group: start
 ---
 
 ## What is ManageIQ?


### PR DESCRIPTION
This change enables training slashes for directories, and no trailing slashes
for files. The way it ought to be!

It now correctly marks TOC items under "Get started" as active. And this also
centralizes a few permalink and doc_group settings into _config.yml.