### PR TITLE
Cleanup to the getting started guide.

### DIFF
--- a/site/_assets/css/_docs.scss
+++ b/site/_assets/css/_docs.scss
@@ -105,6 +105,10 @@
       margin-top: 0;
     }
 
+    h2 {
+      margin: 1em 0;
+    }
+
     table {
       max-width: 100%;
       margin-bottom: 1em;
@@ -197,6 +201,15 @@
 
   #toctitle {
     margin-bottom: 1em;
+  }
+
+  .start_doc {
+    img {
+      display: block;
+      max-width: 90%;
+      height: auto;
+      margin: 2em auto;
+    }
   }
 
   .user_doc {

--- a/site/docs/get-started/cloud.md
+++ b/site/docs/get-started/cloud.md
@@ -1,26 +1,29 @@
 ---
 layout: doc_page
-doc_group: start
 title: Easy Install Using A Public Cloud Provider
 ---
-The installation of ManageIQ consists on two phases:
 
- 1. Install ManageIQ as a cloud image in the cloud
- 2. Connect it to a managed system, and start working with it.
+You can try ManageIQ in one of the public clouds that are supported. The
+benefits of this option are that you don't need any hardware yourself, and that
+you can also use the same public cloud as the platform to be managed.
 
-We will use the Google Cloud Platform as an example, so you need to open an account. Free accounts can be opened in [Google Cloud](https://console.cloud.google.com/freetrial) for eligible users.
+In the instructions below we will use the Google Cloud Platform. The ManageIQ
+project publishes ready-to-use images on [Google
+Storage](https://console.cloud.google.com/storage/browser/manageiq). We will
+assume that you have a Google account with an active payment method or a free
+trial. You also need to make sure that you have a default keypair installed.
 
-![screenshot0037](/assets/images/docs/screenshot_0037.png){:.img-responsive}
+The ManageIQ project is working on making it easy to try out ManageIQ on other
+clouds as well.
 
-## 1. Installing ManageIQ as a cloud image ##
-### Step 1. Create a new image ###
-From console.cloud.google.com, go to "Compute Engine" and then "Images"
+### Step 1: Create a new image
 
-![screenshot0038](/assets/images/docs/screenshot_0038.png){:.img-responsive}
-
-Create a new image:
+From console.cloud.google.com, go to "Compute Engine", "Images" and then click
+on "Create Image":
 
 ![screenshot0040](/assets/images/docs/screenshot_0040.png){:.img-responsive}
+
+Fill in the following data:
 
 **Name:** manageiq-darga-3
 
@@ -30,50 +33,20 @@ Create a new image:
 
 **Cloud storage file:** manageiq/darga-3.tar.gz
 
-### Step 2. Create a new instance using the image you created
+### Step 2: Create a new instance using the image you created
 
-Once the image is created, you can create a new instance based on this
-image. It's recommended to select the 2 CPU / 7.5GB instance.
-![screenshot0041](/assets/images/docs/screenshot_0041.png){:.img-responsive}
-
-While creating the image, select in firewalls:
-~~~~
--[x] Allow HTTP traffic
--[x] Allow HTTPS traffic
-~~~~
+Once the image is created, you can create a new instance based on this image.
+Go to "Compute Engine", "VM instances and then click on "Create instance".
 
 ![screenshot0042](/assets/images/docs/screenshot_0042.png){:.img-responsive}
 
-```
-#### [NOTE]
-Access to console via ssh is similar to other systems, but as the user is non-privileged, you will need to use
- $ sudo appliance_console
-====
-```
-## 2. Configure managed systems
-### Step 3. Add an infrastructure or cloud provider ###
+It's recommended to select the 2 CPU / 7.5GB instance. Under "boot disk",
+select the image that you created above. You also need to make sure that HTTP
+traffic is enabled.
 
-Now that your ManageIQ Appliance is up and running, it's time to connect up with your Providers (Cloud or Infrastructure) and gather data about them. There are detailed instructions for each provider in the documentation.
+Now hit "Create" to start the instance.
 
-#### Discover a new infrastructure provider
+ManageIQ is now up and running.
 
-For Microsoft SCVMM, RHEV, oVirt, or vSphere
-
- * Navigate to ***Infrastructure → Providers***
- * Click ***Configuration → Discover Infrastructure Providers***
- * Select the type.
- * Enter an IP Range.
- * Click ***Add***.
-
-
-#### Discover a new cloud provider
-
-For OpenStack, Amazon EC2, Azure, Google Cloud Engine:
-
- * Navigate to ***Clouds → Providers***
- * Click ***Configuration → Add a New Cloud Provider***
- * Select the type.
- * Enter required credentials.
- * Click ***Add***.
-
-## Next: [Basic Configuration](/docs/get-started/basic-configuration)
+Next step is to perform some [basic
+configuration](/docs/get-started/basic-configuration).

--- a/site/docs/get-started/docker.md
+++ b/site/docs/get-started/docker.md
@@ -1,65 +1,28 @@
 ---
 layout: doc_page
-doc_group: start
 title: Easy Install With Docker
 ---
 
-You can test ManageIQ running in a Docker container using images from the [Docker hub](https://hub.docker.com/).
+You can test ManageIQ running in a Docker container using the images that the
+ManageIQ project makes available on the [Docker Hub](https://hub.docker.com/r/manageiq).
+This is a great option if you have a Linux PC (but it works everywhere Docker
+is available).
 
-The installation consists of two phases:
+### Step 1: Download and deploy the appliance
 
- 1. Install ManageIQ in your local machine inside a Docker container, and then configure it
- 2. Connect to a managed system, and start working with it.
+Pull the ManageIQ docker image:
 
-## Installing ManageIQ as a docker container ##
-### Step 1. Install docker in your machine
-You can follow instructions for your specific OS in the [Get Started with Docker](https://docs.docker.com/engine/getstarted/step_one/#step-1-get-docker)
+```bash
+$ sudo docker pull manageiq/manageiq:latest-darga
+```
 
-Additional details on how to configure the system properly can be found in the links above.
+### Step 2: Run the container
 
-### Step 2. Download and deploy the appliance
+```bash
+$ sudo docker run -d -p 8443:443 manageiq/manageiq:latest-darga
+```
 
- 1. Pull the ManageIQ docker image from [Docker hub](https://hub.docker.com/) and run it
+ManageIQ is now up and running.
 
-`$ docker run --privileged -di -p 80:80 -p 443:443 docker.io/manageiq/manageiq:darga-3`
-
-You can use other tags to get different versions of the container: [*latest, latest-darga, etc*](https://hub.docker.com/r/manageiq/manageiq/).
-
-### Step 3. First connection and configuration
-
-The Docker image is a self starting image that has already been configured. You can connect directly into the appliance and start working with it.
-
- 1. Log into the ManageIQ dashboard by connecting to the new running VM with a web [browser](https://127.0.0.1). The initial username and password is ***admin/smartvm***
-
- 2. There are a number of basic settings, located under <u>"Configure → Configuration"</u> in the web interface, or under <u>"Advanced Settings"</u> in the VM's console, that you may wish to change when starting ManageIQ for the first time. Among the most common are:
-
-    * Time and date settings
-    * Hostname
-    * Admin password
-
-## Configure managed systems
-### Step 4. Add an infrastructure or cloud provider ###
-
-Now that your ManageIQ Appliance is up and running, it's time to connect up with your Providers (Cloud or Infrastructure) and gather data about them. There are detailed instructions for each provider in the documentation.
-
-#### Discover a new infrastructure provider
-
-For Microsoft SCVMM, RHEV, oVirt, or vSphere
-
- * Navigate to ***Infrastructure → Providers***
- * Click ***Configuration → Discover Infrastructure Providers***
- * Select the type.
- * Enter an IP Range.
- * Click ***Add***.
-
-#### Discover a new cloud provider
-
-For OpenStack, Amazon EC2, Azure, Google Cloud Engine:
-
- * Navigate to ***Clouds → Providers***
- * Click ***Configuration → Add a New Cloud Provider***
- * Select the type.
- * Enter required credentials.
- * Click ***Add***.
-
-## Next: [Basic Configuration](/docs/get-started/basic-configuration)
+Next step is to perform some [basic
+configuration](/docs/get-started/basic-configuration).

--- a/site/docs/get-started/index.md
+++ b/site/docs/get-started/index.md
@@ -3,35 +3,36 @@ layout: doc_page
 title: Get Started
 ---
 
-## What is ManageIQ?
+ManageIQ is an open source management platform for Hybrid IT. It can manage
+small and large environments, and supports multiple technologies such as
+virtual machines, public clouds and containers.
 
-MangeIQ is an open source management platform for hybrid IT. Agile, Efficient and Risk Managed IT infrastructure, through:
+With ManageIQ you will be able to:
 
-* Continuous **discovery** of managed environments.
-* Unified operations **management across hybrid footprints**.
-* **Self-service** with complete life-cycle management.
-* **Compliance enforcement** for any changes, applied or discovered.
-* **Platform** based approach, allowing for fast implementation and coexistence with other management tools
+* Continuously discover the latest state of your environment.
+* Implement **self service** for your end users.
+* Enforce **compliance** across the environment.
+* Optimize the performance and utilization of you environment.
 
 ## Following this Guide
 
-In order to follow this guide, you will need a computer that allows you to run the software and a provider to connect to. ManageiQ can be installed in many different providers, virtual or cloud. We will provide some options in this tutorial but you can check in the documentation for other options.
-Requirements vary depending on your choice.
+In order to follow this guide, you will need:
 
-There is a concept guide that you can check if you need a definition:
-[Concepts Guide](/docs/get-started/concepts)
+* Somewhere to run the ManageIQ software.
+* Something to manage.
 
+When used in production environments, ManageIQ users typically download [one of
+our virtual appliances](/download) and deploy copies of it onto a
+virtualization platform like OpenStack or VMware. The appliance is then
+configured to connect to the virtualization platform so that it can be managed.
 
-Current options are:
+For this getting started guide however, we will focus on a simpler way for you
+to get to know ManageIQ, one that does not require access to a virtualization
+platform. We describe three easy options:
 
- - [Docker](/docs/get-started/docker) (if you use the Docker option)
- - [Vagrant](/docs/get-started/vagrant) (if you use the Vagrant option)
- - [Cloud](/docs/get-started/cloud) (if you use the Cloud option)
+ - [Vagrant](/docs/get-started/vagrant) -- run ManageIQ as a Vagrant Box
+ - [Docker](/docs/get-started/docker) -- run ManageIQ as a Docker container
+ - [Public Cloud](/docs/get-started/cloud) -- run ManageIQ in the cloud
 
-You would also need a system to manage, we will use a free sign-up Google Cloud Platform account for testing, but you can use any provider supported by ManageIQ
-
-## Next: Get the ManageIQ Appliance
-
-### [Try ManageIQ with Docker](/docs/get-started/docker)
-### [Try ManageIQ with Vagrant](/docs/get-started/vagrant)
-### [Try ManageIQ with a Public Cloud Provider](/docs/get-started/cloud)
+We will use the Google Cloud Platform as the platform to manage (but you can
+use any public cloud supported by ManageIQ).

--- a/site/docs/get-started/vagrant.md
+++ b/site/docs/get-started/vagrant.md
@@ -1,81 +1,66 @@
 ---
 layout: doc_page
-doc_group: start
 title: Easy Install With Vagrant
 ---
 
-You can test ManageIQ running in a Vagrant box using images from [Atlas](https://atlas.hashicorp.com/vagrant).
+You can test ManageIQ with Vagrant using the images that the ManageIQ project
+makes available on [Atlas](https://atlas.hashicorp.com/manageiq). This is a
+great option if you have a Windows PC or a Mac. Note that you need 8GB of
+memory to run ManageIQ!
 
-The installation consists of two phases:
+We will assume that you have Vagrant
+[installed](https://www.vagrantup.com/docs/installation/) on your computer, and
+that it is configured with VirtualBox as the hypervisor. Currently only
+VirtualBox boxes are provided.
 
-1. Install ManageIQ in your local machine inside a Vagrant box and configure it
-2. Connect to a managed system, and start working with it.
+### Step 1: Create a new box
 
-## Installing ManageIQ as a Vagrant box ##
-### Step 1. Install Vagrant in your machine
-You can follow instructions for your specific OS in the [Vagrant downloads](https://www.vagrantup.com/downloads.html)
+Execute the following commands to create a new Vagrant box:
 
-Additional details on how to configure the system properly can be found in the links above.
-
-### Step 2. Download and deploy the appliance
-
-1. Pull the ManageIQ Vagrant box from [Atlas](https://atlas.hashicorp.com/manageiq) and run it
 ```bash
-    $ mkdir manageiq-vagrant; cd manageiq-vagrant
-    $ vagrant init manageiq/darga
-```
-2. Modify the Vagrantfile if you want to add more memory and CPU (currently configured for 6144 MB and 4 CPU)
-For instance, this at the beginning of the Vagrant file will make sure that you always call it with virtualbox
-````
-# Vagrantfile
-ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+$ mkdir manageiq
+$ cd manageiq
+$ vagrant init manageiq/darga
 ```
 
-You can use other tags to get different versions of the container: *latest, latest-darga, etc*.
+There is now a `Vagrantfile` in the current directory.
 
-3. Start the vagrant image
+### Step 2: Modify Vagrantfile
+
+You need to expose the ManageIQ web interface. Add the following setting to
+the `Vagrantfile`:
+
+```ruby
+config.vm.network "forwarded_port", guest: 443, host: 8443
+```
+This will create a port mapping so that the ManageIQ web interface can be found
+on https://localhost:8443.
+
+By default ManageIQ is configured to use 6144MB and 4 CPUs. You can slightly
+tune this down, but you should not go below the following settings:
+
+```ruby
+config.vm.provider "virtualbox" do |vb|
+  vb.memory = 4096
+  vb.cpus = 2
+end
+```
+
+### Step 3: Start ManageIQ
+
+Start ManageIQ by executing:
+
 ```bash
-    $ vagrant up
+$ vagrant up
 ```
-You can also use *vagrant up --provider virtualbox*
 
+Ensure you can login to the ManageIQ appliance:
 
-### Step 3. First connection and configuration
+```bash
+$ vagrant ssh
+```
 
-The Vagrant image is a self starting image that has already been configured. You can connect directly into the appliance and start working with it.
+ManageIQ is now up and running.
 
-1. Log into the ManageIQ dashboard by connecting to the new running VM with a web [browser](http://172.28.128.3/). The initial username and password is ***admin/smartvm***
-
-2. There are a number of basic settings, located under <u>"Configure → Configuration"</u> in the web interface, or under <u>"Advanced Settings"</u> in the VM's console, that you may wish to change when starting ManageIQ for the first time. Among the most common are:
-
-* Time and date settings
-* Hostname
-* Admin password
-
-
-## Configure managed systems
-### Step 4. Add an infrastructure or cloud provider ###
-
-Now that your ManageIQ Appliance is up and running, it's time to connect up with your Providers (Cloud or Infrastructure) and gather data about them. There are detailed instructions for each provider in the documentation.
-
-#### Discover a new infrastructure provider
-
-For Microsoft SCVMM, RHEV, oVirt, or vSphere
-
-* Navigate to ***Infrastructure → Providers***
-* Click ***Configuration → Discover Infrastructure Providers***
-* Select the type.
-* Enter an IP Range.
-* Click ***Add***.
-
-#### Discover a new cloud provider
-
-For OpenStack, Amazon EC2, Azure, Google Cloud Engine:
-
-* Navigate to ***Clouds → Providers***
-* Click ***Configuration → Add a New Cloud Provider***
-* Select the type.
-* Enter required credentials.
-* Click ***Add***.
-
-## Next: [Basic Configuration](/docs/get-started/basic-configuration)
+Next step is to perform some [basic
+configuration](/docs/get-started/basic-configuration).


### PR DESCRIPTION
The image styles are currently a crude hack. Someone with CSS experience should
have a look at this (Eric that may be you :).

The main changes are:

* Don't explain how to get started with the three options. Assume people that select an option already have Vagrant, Docker, or Google.

* Focus Vagrant on Windows and Mac users, and Docker on Linux users. I expect this to be the main audiences for these options.

* Since we have separate chapters on configuration and adding a provider, there should be no need to repeat those in the Vagrant, Docker and Cloud sections.

* Added some instructions for port mapping on Vagrant. I've chosen port 8443 as the standard port, and use that for Docker as well.