### PR TITLE
Add a LWIMIQ post generator

### DIFF
--- a/exe/miq
+++ b/exe/miq
@@ -111,6 +111,14 @@ module Miq
     end
   end
 
+  class Generate < Thor
+    desc "lwimiq", "Generate a LWIMIQ blog post"
+    def lwimiq(week_beginning)
+      say "Generating LWIMIQ post", :green
+      Lwimiq.generate(week_beginning)
+    end
+  end
+
   #
   # Top level command
   #
@@ -123,6 +131,9 @@ module Miq
 
     desc "build <all|guides|site|reference>", "Build or process an aspect of the site"
     subcommand "build", Build
+
+    desc "generate lwimiq YYYY-MM-DD", "Generate a new blog post"
+    subcommand "generate", Generate
 
     # desc "deploy", "Prepares and deploys site. Don't use unless your changes have been pushed to repos."
     # def deploy

--- a/lib/miq.rb
+++ b/lib/miq.rb
@@ -22,6 +22,8 @@ require_relative "miq/md_link_converter"
 require_relative "miq/dir_index"
 require_relative "miq/tag_index"
 
+require_relative "miq/lwimiq"
+
 module Miq
   def self.working_dir
     if ENV["MIQ_BASE_DIR"]

--- a/lib/miq/lwimiq.rb
+++ b/lib/miq/lwimiq.rb
@@ -1,0 +1,70 @@
+module Miq
+  class Lwimiq
+    def self.generate(start_date)
+      new(start_date).generate
+    end
+
+    attr_reader :start_date, :end_date
+
+    def initialize(start_date)
+      @start_date = Date.parse(start_date)
+      @end_date = @start_date + 6
+    end
+
+    def generate
+      File.open(path, "w") { |f| f.write(content) }
+      system "#{ENV['EDITOR'] || 'open'} #{path}"
+    end
+
+    def path
+      File.join("site", "blog", "#{Date.today.strftime("%Y-%m-%d")}-CHANGE-ME.md")
+    end
+
+    def content
+      <<-EOF
+---
+title: "Last Week in ManageIQ: <subtitle>"
+author: <author>
+date: #{DateTime.now.strftime("%Y-%m-%d %H:%M:%S %Z")}
+comments: true
+published: true
+tags: LWIMIQ
+---
+
+<intro>
+
+## Featured
+
+<prs merged>
+<important news>
+
+## Improved
+
+### <pr 1>
+### <pr 2>
+
+## Fixed
+
+### <pr 1>
+### <pr 2>
+
+## New
+
+### <pr 1>
+### <pr 2>
+
+## Deleted
+
+### <pr 1>
+### <pr 2>
+
+## Wrapping up
+
+<outro>
+
+[PRs merged last week]: https://github.com/ManageIQ/manageiq/pulls?page=1&q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A%22#{start_date.strftime("%Y-%m-%d")}+..+#{end_date.strftime("%Y-%m-%d")}%22+sort%3Acreated-desc&utf8=%E2%9C%93
+[Commits merged last week]: https://github.com/manageiq/manageiq/compare/master@%7B#{start_date.strftime("%Y-%m-%d")}%7D...@%7B#{end_date.strftime("%Y-%m-%d")}%7D
+EOF
+    end
+  end
+end


### PR DESCRIPTION
With this revision I mostly wanted a generator that took the pain out of
fiddling with dates and inserting them into GitHub URLs, and also
provide a skeleton that represents the form I typically use every time I
make a LWIMIQ blog post. With this added, an author can type in the
start date of the week concerned and get a blog post skeleton back with
working links.

The intention of this is not to set that form in stone - I love reading
posts that deviate from this formula, or even abandon it completely. But
I personally like having a blog post skeleton that gets me over the
blank canvas stage.

@hayesr LMK what you think, especially if my namespacing/documentation could use a little help :wink: