### PR TITLE
Gem bump and fix blog post timestamp

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,9 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.4.0)
-    autoprefixer-rails (6.5.0.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    autoprefixer-rails (6.5.3)
       execjs
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
@@ -28,10 +29,10 @@ GEM
     execjs (2.7.0)
     extras (0.1.0)
       forwardable-extended (~> 2.5)
-    fastimage (2.0.0)
+    fastimage (2.0.1)
       addressable (~> 2)
     ffi (1.9.14)
-    font-awesome-sass (4.6.2)
+    font-awesome-sass (4.7.0)
       sass (>= 3.2)
     formatador (0.2.5)
     forwardable-extended (2.6.0)
@@ -55,7 +56,8 @@ GEM
       minitest (>= 3.0)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
-    jekyll (3.2.1)
+    jekyll (3.3.0)
+      addressable (~> 2.4)
       colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
@@ -77,7 +79,8 @@ GEM
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.4.0)
       sass (~> 3.4)
-    jekyll-sitemap (0.10.0)
+    jekyll-sitemap (0.12.0)
+      jekyll (~> 3.3)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
     kramdown (1.12.0)
@@ -104,9 +107,10 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rack (1.6.4)
+    public_suffix (2.0.4)
+    rack (1.6.5)
     rake (11.3.0)
-    rb-fsevent (0.9.7)
+    rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     ref (2.0.0)
@@ -149,4 +153,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.13.0.rc.2
+   1.13.6

--- a/site/_posts/2016-11-11-vote-on-naming-f-release.html.md
+++ b/site/_posts/2016-11-11-vote-on-naming-f-release.html.md
@@ -1,8 +1,8 @@
 ---
 title: Voting on Name of F Release
 author: chessbyte
-date: 2016-11-11 20:02:24 UTC
-tags: releases collaboration announcments
+date: 2016-11-11 09:02:24 UTC
+tags: releases collaboration announcements
 comments: true
 published: true
 ---
@@ -29,4 +29,3 @@ Vote [HERE](need to update once poll is created on talk) for your favorite by ma
 Votes entered by Friday, November 18th will be tallied and the name will be announced on Monday November 21st. This is also the scheduled release date for Euwe GA.
 
 *SPECIAL NOTE*: [The FIDE World Chess Championship Match 2016](https://worldchess.com/nyc2016/) between Magnus Carlsen (Norway) and Sergey Karjakin (Russia), is being held in New York City November 11-30, 2016
-


### PR DESCRIPTION
Post date was in the future (when checked without timezone?), preventing it from being built. 
Might be a Jekyll bug, or related to bad config somewhere.
This also bumps gem versions.