### PR TITLE
Google analytics event tracking for downloads and triad clicks

### DIFF
--- a/site/_includes/triad.html
+++ b/site/_includes/triad.html
@@ -11,7 +11,7 @@
       </div>
       <div class="triad-title">Vagrant</div>
       <div class="triad-button">
-        <a href="/docs/get-started/vagrant" class="btn btn-primary">
+        <a href="/docs/get-started/vagrant" class="btn btn-primary" onClick="ga('send', 'event', { eventCategory: 'Getting Started', eventAction: 'triadclick', eventLabel: 'Vagrant', eventValue: 10, transport: 'beacon' });">
           Try It!
         </a>
       </div>
@@ -25,7 +25,7 @@
       </div>
       <div class="triad-title">Docker</div>
       <div class="triad-button">
-        <a href="/docs/get-started/docker" class="btn btn-primary">
+        <a href="/docs/get-started/docker" class="btn btn-primary" onClick="ga('send', 'event', { eventCategory: 'Getting Started', eventAction: 'triadclick', eventLabel: 'Docker', eventValue: 10, transport: 'beacon' });">
           Try It!
         </a>
       </div>
@@ -39,7 +39,7 @@
       </div>
       <div class="triad-title">Public Cloud</div>
       <div class="triad-button">
-        <a href="/docs/get-started/cloud" class="btn btn-primary">
+        <a href="/docs/get-started/cloud" class="btn btn-primary" onClick="ga('send', 'event', { eventCategory: 'Getting Started', eventAction: 'triadclick', eventLabel: 'Cloud', eventValue: 10, transport: 'beacon' });">
           Try It!
         </a>
       </div>

--- a/site/_includes/triad.html
+++ b/site/_includes/triad.html
@@ -11,7 +11,7 @@
       </div>
       <div class="triad-title">Vagrant</div>
       <div class="triad-button">
-        <a href="/docs/get-started/vagrant" class="btn btn-primary" onClick="ga('send', 'event', { eventCategory: 'Getting Started', eventAction: 'triadclick', eventLabel: 'Vagrant', eventValue: 10, transport: 'beacon' });">
+        <a href="/docs/get-started/vagrant" class="btn btn-primary" onClick="ga('send', 'event', { eventCategory: 'Getting Started', eventAction: 'triadclick', eventLabel: 'Vagrant', transport: 'beacon' });">
           Try It!
         </a>
       </div>
@@ -25,7 +25,7 @@
       </div>
       <div class="triad-title">Docker</div>
       <div class="triad-button">
-        <a href="/docs/get-started/docker" class="btn btn-primary" onClick="ga('send', 'event', { eventCategory: 'Getting Started', eventAction: 'triadclick', eventLabel: 'Docker', eventValue: 10, transport: 'beacon' });">
+        <a href="/docs/get-started/docker" class="btn btn-primary" onClick="ga('send', 'event', { eventCategory: 'Getting Started', eventAction: 'triadclick', eventLabel: 'Docker', transport: 'beacon' });">
           Try It!
         </a>
       </div>
@@ -39,7 +39,7 @@
       </div>
       <div class="triad-title">Public Cloud</div>
       <div class="triad-button">
-        <a href="/docs/get-started/cloud" class="btn btn-primary" onClick="ga('send', 'event', { eventCategory: 'Getting Started', eventAction: 'triadclick', eventLabel: 'Cloud', eventValue: 10, transport: 'beacon' });">
+        <a href="/docs/get-started/cloud" class="btn btn-primary" onClick="ga('send', 'event', { eventCategory: 'Getting Started', eventAction: 'triadclick', eventLabel: 'Cloud', transport: 'beacon' });">
           Try It!
         </a>
       </div>

--- a/site/download/index.md
+++ b/site/download/index.md
@@ -15,19 +15,19 @@ title: Download ManageIQ
       <th>Size</th>
     </tr>
     <tr>
-      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: 'Docker', eventValue: 0, transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
+      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Docker {{release.name}}', transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
       <td>docker</td>
       <td>0.4 GB</td>
     </tr>
     {% for type in site.data.download_types %}
     <tr>
-      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}}', eventValue: 0, transport: 'beacon' });">{{ type.name }}</a></td>
+      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
       <td>{{ type.download_platform }}</td>
       <td>{{ type.size_stable }}</td>
     </tr>
     {% endfor %}
     <tr>
-      <td><a href="https://atlas.hashicorp.com/manageiq/boxes/darga" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: 'Vagrant', eventValue: 0, transport: 'beacon' });">Vagrant</a></td>
+      <td><a href="https://atlas.hashicorp.com/manageiq/boxes/darga" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Vagrant {{release.name}}', transport: 'beacon' });">Vagrant</a></td>
       <td>vagrant</td>
       <td>1.3 GB</td>
     </tr>
@@ -48,19 +48,19 @@ title: Download ManageIQ
       <th>Size</th>
     </tr>
     <tr>
-      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: 'Docker', eventValue: 1, transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
+      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Docker {{release.name}}', transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
       <td>docker</td>
       <td>0.4 GB</td>
     </tr>
     {% for type in site.data.download_types %}
     <tr>
-      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}}', eventValue: 1, transport: 'beacon' });">{{ type.name }}</a></td>
+      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
       <td>{{ type.download_platform }}</td>
       <td>{{ type.size_pre }}</td>
     </tr>
     {% endfor %}
     <tr>
-      <td><a href="https://atlas.hashicorp.com/manageiq/boxes/euwe" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: 'Vagrant', eventValue: 1, transport: 'beacon' });">Vagrant</a></td>
+      <td><a href="https://atlas.hashicorp.com/manageiq/boxes/euwe" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Vagrant {{release.name}}', transport: 'beacon' });">Vagrant</a></td>
       <td>vagrant</td>
       <td>1.0 GB</td>
     </tr>
@@ -83,13 +83,13 @@ title: Download ManageIQ
       <th>Size</th>
     </tr>
     <tr>
-      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: 'Docker', eventValue: 2, transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
+      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Docker {{release.name}}', transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
       <td>docker</td>
       <td>0.5 GB</td>
     </tr>
     {% for type in site.data.download_types %}
     <tr>
-      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}}', eventValue: 2, transport: 'beacon' });">{{ type.name }}</a></td>
+      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
       <td>{{ type.download_platform }}</td>
       <td>{{ type.size_devel }}</td>
     </tr>

--- a/site/download/index.md
+++ b/site/download/index.md
@@ -15,19 +15,19 @@ title: Download ManageIQ
       <th>Size</th>
     </tr>
     <tr>
-      <td><a href="https://hub.docker.com/r/manageiq/manageiq/">Docker (tag {{release.tag}})</a></td>
+      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: 'Docker', eventValue: 0, transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
       <td>docker</td>
       <td>0.4 GB</td>
     </tr>
     {% for type in site.data.download_types %}
     <tr>
-      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}">{{ type.name }}</a></td>
+      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}}', eventValue: 0, transport: 'beacon' });">{{ type.name }}</a></td>
       <td>{{ type.download_platform }}</td>
       <td>{{ type.size_stable }}</td>
     </tr>
     {% endfor %}
     <tr>
-      <td><a href="https://atlas.hashicorp.com/manageiq/boxes/darga">Vagrant</a></td>
+      <td><a href="https://atlas.hashicorp.com/manageiq/boxes/darga" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: 'Vagrant', eventValue: 0, transport: 'beacon' });">Vagrant</a></td>
       <td>vagrant</td>
       <td>1.3 GB</td>
     </tr>
@@ -48,19 +48,19 @@ title: Download ManageIQ
       <th>Size</th>
     </tr>
     <tr>
-      <td><a href="https://hub.docker.com/r/manageiq/manageiq/">Docker (tag {{release.tag}})</a></td>
+      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: 'Docker', eventValue: 1, transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
       <td>docker</td>
       <td>0.4 GB</td>
     </tr>
     {% for type in site.data.download_types %}
     <tr>
-      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}">{{ type.name }}</a></td>
+      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}}', eventValue: 1, transport: 'beacon' });">{{ type.name }}</a></td>
       <td>{{ type.download_platform }}</td>
       <td>{{ type.size_pre }}</td>
     </tr>
     {% endfor %}
     <tr>
-      <td><a href="https://atlas.hashicorp.com/manageiq/boxes/euwe">Vagrant</a></td>
+      <td><a href="https://atlas.hashicorp.com/manageiq/boxes/euwe" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: 'Vagrant', eventValue: 1, transport: 'beacon' });">Vagrant</a></td>
       <td>vagrant</td>
       <td>1.0 GB</td>
     </tr>
@@ -83,13 +83,13 @@ title: Download ManageIQ
       <th>Size</th>
     </tr>
     <tr>
-      <td><a href="https://hub.docker.com/r/manageiq/manageiq/">Docker (tag {{release.tag}})</a></td>
+      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: 'Docker', eventValue: 2, transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
       <td>docker</td>
       <td>0.5 GB</td>
     </tr>
     {% for type in site.data.download_types %}
     <tr>
-      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}">{{ type.name }}</a></td>
+      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}}', eventValue: 2, transport: 'beacon' });">{{ type.name }}</a></td>
       <td>{{ type.download_platform }}</td>
       <td>{{ type.size_devel }}</td>
     </tr>


### PR DESCRIPTION
Fields:
- `eventCategory`
  - 'Getting Started' refers to the quick start guides
  - 'Appliance' refers to the appliances for downloading
- `eventAction`
  - 'triadclick': clicked from the triad in front page (to differentiate clicks from other sources)
  - 'outbound': link to external site for the download (e.g. for Docker and Vagrant)
  - 'download': link to image on releases.manageiq.org
- `eventLabel`
  - the type and release, e.g. oVirt Nightly, OpenStack Darga-5