### PR TITLE
Add more contributor links to various repos

### DIFF
--- a/site/_data/github_repos.yaml
+++ b/site/_data/github_repos.yaml
@@ -1,0 +1,48 @@
+- name: manageiq
+  description: ManageIQ Open-Source Management Platform
+
+- name: manageiq-ui-classic
+  description: Classic UI of ManageIQ
+
+- name: manageiq-ui-service
+  description: Service UI for ManageIQ
+
+- name: manageiq-appliance
+  description: System files for the ManageIQ appliance
+
+- name: manageiq-appliance-build
+  description: Scripts to build ManageIQ appliances
+
+- name: manageiq-content
+  description: Default ManageIQ content
+
+- name: manageiq-gems-pending
+  description: Gems Pending to be extracted for ManageIQ project
+
+- name: manageiq-providers-amazon
+  description: ManageIQ plugin for the Amazon EC2 provider
+
+- name: manageiq-providers-azure
+  description: ManageIQ plugin for the Microsoft Azure provider
+
+- name: manageiq-providers-lenovo
+  description: ManageIQ plugin for the Lenovo XClarity provider
+
+- name: manageiq-api-client
+  description: Ruby client library to the ManageIQ REST API
+
+- name: manageiq-pods
+  description: ManageIQ on OpenShift
+
+- name: manageiq_docs
+  description: Documentation for the ManageIQ Cloud Management Platform
+
+- name: integration_tests
+  description: ManageIQ integration tests
+
+- name: ui-components
+  description: Angular UI Components for ManageIQ
+
+- name: manageiq.org
+  description: Website for the ManageIQ Cloud Management Platform
+

--- a/site/community.md
+++ b/site/community.md
@@ -15,7 +15,10 @@ ManageIQ is open source and open for contributions. There are many ways to get i
 
   <div class="col-md-6">
     <br /><p><a href="https://github.com/orgs/ManageIQ/people">Members in ManageIQ community</a></p>
-    <p><a href="https://github.com/ManageIQ/manageiq/graphs/contributors">Contributors to the main ManageIQ repo</a></p>
+    <p>Contributors to the ManageIQ repositories:</p>
+    {% for repo in site.data.github_repos %}
+    <small>&#9823;&nbsp;<a href="https://github.com/ManageIQ/{{repo.name}}/graphs/contributors" title="{{repo.description}}">{{repo.name}}</a></small>
+    {% endfor %}
   </div>
 </div>
 
@@ -129,7 +132,7 @@ Here are some opportunities to meet with members of the community to learn and s
 
 ### Sprint reviews
 
-There is a ManageIQ Sprint review every 3 weeks open to the community. To join the online video conference, please use this [Bluejeans link](https://bluejeans.com/5927041376/).
+There is a ManageIQ Sprint review every 2 weeks open to the community. To join the online video conference, please use this [Bluejeans link](https://bluejeans.com/5927041376/).
 
 You can import the [ManageIQ community calendar](https://calendar.google.com/calendar/embed?src=contact%40manageiq.org) to be notified about ManageIQ events and Sprint reviews.
 


### PR DESCRIPTION
Link to contributors of the following repos under ManageIQ:

- manageiq
- manageiq-ui-classic
- manageiq-ui-service
- manageiq-appliance
- manageiq-appliance-build
- manageiq-content
- manageiq-gems-pending
- manageiq-providers-amazon
- manageiq-providers-azure
- manageiq-providers-lenovo
- manageiq-api-client
- manageiq-pods
- manageiq_docs
- integration_tests
- ui-components
- manageiq.org

More repos can be added to github_repos.yaml

Change sprint review frequency info as announced today (3 weeks -> 2 weeks)