### PR TITLE
Sprint schedule change - blog post

### DIFF
--- a/site/_posts/2017-01-05-schedule-change-3-week-sprints-to-2-week-sprints.md
+++ b/site/_posts/2017-01-05-schedule-change-3-week-sprints-to-2-week-sprints.md
@@ -7,7 +7,7 @@ comments: true
 published: true
 ---
 
-Happy New Year! We're starting off 2017 with a notable change in the ManageIQ process. In an effort to become more agile, and allow more flexibility in planning and scheduling, we will be switiching from 3-week Sprints to 2-week Sprints.
+Happy New Year! We're starting off 2017 with a notable change in the ManageIQ process. In an effort to become more agile, and allow more flexibility in planning and scheduling, we will be switching from 3-week Sprints to 2-week Sprints.
 
 We had the Sprint 51 review meeting yesterday (Jan 4) as planned, and from now on the meetings will occur fortnightly. The next 3 sprint reviews are as follows:
 

--- a/site/_posts/2017-01-05-schedule-change-3-week-sprints-to-2-week-sprints.md
+++ b/site/_posts/2017-01-05-schedule-change-3-week-sprints-to-2-week-sprints.md
@@ -1,0 +1,21 @@
+---
+title: "Schedule change: 3-week Sprints to 2-week Sprints"
+author: cybette
+date: 2017-01-05 15:30:45 UTC
+tags: sprints collaboration
+comments: true
+published: true
+---
+
+Happy New Year! We're starting off 2017 with a notable change in the ManageIQ process. In an effort to become more agile, and allow more flexibility in planning and scheduling, we will be switiching from 3-week Sprints to 2-week Sprints.
+
+We had the Sprint 51 review meeting yesterday (Jan 4) as planned, and from now on the meetings will occur fortnightly. The next 3 sprint reviews are as follows:
+
+- [Sprint 52: January 18, 2017 @ 7:30 PST/10:30 EST/15:30 GMT](http://www.timeanddate.com/worldclock/fixedtime.html?msg=ManageIQ+Sprint+52+review&iso=20170118T1530)
+- [Sprint 53: February 1, 2017 @ 7:30 PST/10:30 EST/15:30 GMT](http://www.timeanddate.com/worldclock/fixedtime.html?msg=ManageIQ+Sprint+53+review&iso=20170201T1530)
+- [Sprint 54: February 15, 2017 @ 7:30 PST/10:30 EST/15:30 GMT](http://www.timeanddate.com/worldclock/fixedtime.html?msg=ManageIQ+Sprint+54+review&iso=20170215T1530)
+
+As always, you can participate in the ManageIQ Sprint review via [Bluejeans](https://bluejeans.com/5927041376/), and import the [ManageIQ community calendar](https://calendar.google.com/calendar/embed?src=contact%40manageiq.org), which has been updated with the abovementioned change. If you missed the meetings, you can find a recap in the [Sprint review blog posts](/blog/tags/sprints/).
+
+See you at Sprint 52 in 2 weeks!
+


### PR DESCRIPTION
Notifying the change of sprint length from 3 weeks to 2 weeks.