### PR TITLE
Change how developer guides are built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _site
 .env
 
 dest/
+site/docs/guides
 site/docs/reference/latest/
 site/.asset-cache
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "site/docs/guides"]
-	path = site/docs/guides
-	url = https://github.com/ManageIQ/guides.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ ENV MIQ_BUNDLER=/root/.rbenv/shims/bundle
 
 ENV MIQ_BASE_DIR=/srv/build
 ENV MIQ_DOCS_DIR=/srv/build/site/docs
-ENV MIQ_GUIDES_DIR=${MIQ_DOCS_DIR}/guides
+
+ENV MIQ_GUIDES_REPO=https://github.com/manageiq/guides
+ENV MIQ_GUIDES_BRANCH=master
 
 ENV MIQ_SITE_DEST=/srv/manageiq_org
 ENV MIQ_SITE_SOURCE=${MIQ_BASE_DIR}/site

--- a/exe/miq
+++ b/exe/miq
@@ -81,9 +81,8 @@ module Miq
       Guides.build
     end
 
-    desc "site", "Build Jekyll site (and guides)"
+    desc "site", "Build Jekyll site"
     def site
-      invoke :guides
       say "Building Jekyll site", :green
       Site.build
     end
@@ -99,7 +98,7 @@ module Miq
     desc "menus", "Regenerate menu yaml files"
     def menus
       say "Rebuilding menu yaml files", :red
-      say "This will clobber existing files.", :red
+      say "This will clobber existing files in tmp.", :red
       answer = ask("Are you sure? Y/n")
 
       if answer == "Y"
@@ -135,15 +134,8 @@ module Miq
     desc "generate lwimiq YYYY-MM-DD", "Generate a new blog post"
     subcommand "generate", Generate
 
-    # desc "deploy", "Prepares and deploys site. Don't use unless your changes have been pushed to repos."
-    # def deploy
-    #   invoke 'miq:update:all'
-    #   invoke 'miq:build:all'
-    # end
-
     desc "serve", "Does Jekyll serve with appropriate args"
     def serve
-      invoke 'miq:build:guides'
       Site.serve
     end
   end

--- a/lib/miq/guides.rb
+++ b/lib/miq/guides.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/object/blank"
+
 module Miq
   class Guides < Executor
     def self.reset
@@ -12,39 +14,105 @@ module Miq
       new.build
     end
 
-    attr_reader :guides_dir
+    attr_reader :repo, :branch, :tmp_dir, :src_dir, :dst_dir
 
     def initialize
-      @guides_dir = Miq.site_dir.join( (ENV["MIQ_GUIDES_DIR"] || "docs/guides") )
+      # Where do the docs live?
+      @repo     = ENV["MIQ_GUIDES_REPO"] || "https://github.com/ManageIQ/guides.git"
+
+      # What branch to checkout?
+      @branch   = ENV["MIQ_GUIDES_BRANCH"] || "master"
+
+      # Where should we cache and build?
+      @tmp_dir  = ENV["MIQ_GUIDES_TMP"]  || "/tmp/guides"
+
+      # What subdirectory do we want?
+      @src_dir  = ENV["MIQ_GUIDES_SRC"]
+
+      # Where should the files end up?
+      @dst_dir  = ENV["MIQ_GUIDES_DST"]  || Miq.docs_dir.join("guides")
     end
 
     def reset
-      shell "cd #{guides_dir} && git reset --hard HEAD"
-    end
+      logger.info "Removing #{tmp_dir}"
+      logger.info "Removing files and directories from #{dst_dir}"
 
-    def update
-      reset
-      shell "git submodule update"
-    end
+      unless debug?
+        rm_dir(tmp_dir)
 
-    def build
-      add_front_matter
-    end
-
-    # Adds front matter for Jekyll compat
-    def add_front_matter
-      Dir["#{guides_dir}/**/*.md"].each do |path|
-        content = File.readlines(path)
-
-        unless content[0] == "---\n"
-          File.open(path, "w") do |f|
-            f.puts "---\n---\n"
-            content.each {|line| f.puts line }
+        Dir["#{dst_dir}/*"].each do |path|
+          if File.directory?(path)
+            rm_dir(path)
+          else
+            File.delete(path)
           end
         end
       end
     end
 
+    def build
+      clone_or_update_repo
+      sync_files
+      add_front_matter
+    end
+
+    def update
+      clone_or_update_repo
+    end
+
+    def clone_or_update_repo
+      if File.directory?(tmp_dir)
+        logger.info "Updating local guides repo"
+        shell "cd #{tmp_dir} && git pull origin"
+      else
+        logger.info "Cloning #{repo} to #{tmp_dir}"
+        shell "git clone #{repo} --depth 1 #{tmp_dir}"
+      end
+    end
+
+    # Adds YAML front matter for Jekyll compat
+    def add_front_matter
+      logger.info "Adding front matter"
+
+      Dir["#{dst_dir}/**/*.md"].each do |path|
+        content = File.readlines(path)
+
+        unless content[0] == "---\n"
+          File.open(path, "w") do |f|
+            f.puts "---\n" * 2
+            content.each { |line| f.puts line }
+          end
+        end
+      end
+    end
+
+    def sync_files
+      if File.directory?("#{tmp_dir}/#{src_dir}") || debug?
+        prep dst_dir
+        logger.info "Syncing files to #{dst_dir}"
+        cmd = "rsync -av "
+        cmd << exclude_files.map{|x| "--exclude '#{x}'"}.join(' ')
+        cmd << " #{sync_target}/* #{dst_dir}/"
+        shell cmd
+      else
+        logger.error "Reference docs source directory not present."
+      end
+    end
+
+    def sync_target
+      if src_dir.blank?
+        tmp_dir
+      else
+        "#{tmp_dir}/#{src_dir}"
+      end
+    end
+
+    private
+
+    # Relative to src_dir
+    def exclude_files
+      []
+    end
     # /Guides
   end
 end

--- a/lib/miq/ref_docs.rb
+++ b/lib/miq/ref_docs.rb
@@ -52,7 +52,7 @@ module Miq
       clone_or_update_repo
       setup_ascii_binder
       build_ref_docs
-      move_files
+      sync_files
     end
 
     def update
@@ -65,7 +65,7 @@ module Miq
         shell "cd #{tmp_dir} && git pull origin"
       else
         logger.info "Cloning #{repo} to #{tmp_dir}"
-        shell "git clone #{repo} #{tmp_dir}"
+        shell "git clone #{repo} --depth 1 #{tmp_dir}"
       end
     end
 
@@ -86,7 +86,7 @@ module Miq
       ].join(" && ")
     end
 
-    def move_files
+    def sync_files
       if File.directory?("#{tmp_dir}/#{src_dir}") || debug?
         prep dst_dir
         logger.info "Syncing files to #{dst_dir}"

--- a/test/lib/miq/guides_test.rb
+++ b/test/lib/miq/guides_test.rb
@@ -3,7 +3,8 @@ require "test_helper"
 class GuidesTest < Minitest::Test
   def setup
     @dir = fixtures_path.join("docs", "guides")
-    ENV["MIQ_GUIDES_DIR"] = @dir.to_s
+    ENV["MIQ_GUIDES_TMP"] = @dir.to_s
+    ENV["MIQ_GUIDES_DST"] = @dir.to_s
     @subject = Miq::Guides.new
   end
 
@@ -11,8 +12,9 @@ class GuidesTest < Minitest::Test
     reset_fixture
   end
 
-  def test_setting_dir_from_env
-    assert_equal @dir, @subject.guides_dir
+  def test_setting_dirs_from_env
+    assert_equal @dir.to_s, @subject.tmp_dir
+    assert_equal @dir.to_s, @subject.dst_dir
   end
 
   def test_adding_front_matter


### PR DESCRIPTION
This removes the `guides` submodule and handles them like the `manageiq_docs` repo.

The git submodule seems like a good idea, but it means a PR to bump the version for every change and submodules can be a pain to deal with. Also this is more consistent.