### PR TITLE
Remove commits merged link from lwimiq generator

### DIFF
--- a/lib/miq/lwimiq.rb
+++ b/lib/miq/lwimiq.rb
@@ -63,7 +63,6 @@ tags: LWIMIQ
 <outro>
 
 [PRs merged last week]: https://github.com/ManageIQ/manageiq/pulls?page=1&q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A%22#{start_date.strftime("%Y-%m-%d")}+..+#{end_date.strftime("%Y-%m-%d")}%22+sort%3Acreated-desc&utf8=%E2%9C%93
-[Commits merged last week]: https://github.com/manageiq/manageiq/compare/master@%7B#{start_date.strftime("%Y-%m-%d")}%7D...@%7B#{end_date.strftime("%Y-%m-%d")}%7D
 EOF
     end
   end


### PR DESCRIPTION
This link has a problem which I believe can't be solved using the GitHub
API:

* if a commit was created before the time period, but merged during the
  time period, it will not appear
* if a commit was created during the time period, but merged after the
  time period, it will retroactively appear, changing the stats

The best alternative I have found to this is running something like the
following in the ManageIQ repo:

```bash
git rev-list --since=<start date> --before=<end date> --merges master | while read rev; do git rev-list $rev ^$rev^; done | wc -l
```

However, I don't think there's a sane way to include that in the generator.

/cc @Fryguy @chrisarcand 