### PR TITLE
Fix hidden menu items in API docs

### DIFF
--- a/site/_assets/css/_menu.scss
+++ b/site/_assets/css/_menu.scss
@@ -13,7 +13,7 @@
   }
 
   li > ul {
-    overflow: scroll;
+    overflow: auto;
     max-height: 0vh;
 
     transition: max-height 0.5s;

--- a/site/_assets/css/_menu.scss
+++ b/site/_assets/css/_menu.scss
@@ -8,9 +8,12 @@
     margin: 0;
   }
 
+  li {
+    margin: 0;
+  }
+
   li > ul {
-    overflow: hidden;
-    // height: 0;
+    overflow: scroll;
     max-height: 0vh;
 
     transition: max-height 0.5s;
@@ -22,7 +25,7 @@
   }
 
   li.menu-open > ul {
-    max-height: 100vh;
+    max-height: 200vh; // Some max-height needed for expansion animation
 
     li {
       opacity: 1;
@@ -56,7 +59,7 @@
 
   // 3rd level
   li > ul > li > ul > li > a {
-    padding-left: $menu-level-pad * 3;
+    padding-left: $menu-level-pad * 2;
   }
 }
 


### PR DESCRIPTION
Addresses #426

This code allows for scrolling menus if they get too long, but adjusts to account for the length of API doc menu items.

**before**
![screen shot 2017-01-17 at 5 28 43 pm](https://cloud.githubusercontent.com/assets/39493/22047247/b11b6f06-dcda-11e6-8506-324240e161f0.png)


**after**
![screen shot 2017-01-17 at 5 29 09 pm](https://cloud.githubusercontent.com/assets/39493/22047250/b7fbed28-dcda-11e6-9a9a-1490eeb157ce.png)
