### PR TITLE
Have lwimiq generator work out the dates

### DIFF
--- a/exe/miq
+++ b/exe/miq
@@ -112,9 +112,10 @@ module Miq
 
   class Generate < Thor
     desc "lwimiq", "Generate a LWIMIQ blog post"
-    def lwimiq(week_beginning)
+    option :current
+    def lwimiq
       say "Generating LWIMIQ post", :green
-      Lwimiq.generate(week_beginning)
+      Lwimiq.generate(options)
     end
   end
 

--- a/lib/miq/lwimiq.rb
+++ b/lib/miq/lwimiq.rb
@@ -1,14 +1,20 @@
 module Miq
   class Lwimiq
-    def self.generate(start_date)
-      new(start_date).generate
+    def self.generate(options)
+      start_date = if options[:current]
+                     Date.today - Date.today.wday + 1
+                   else
+                     Date.today - Date.today.wday - 6
+                   end
+      end_date = start_date + 6
+      new(start_date, end_date).generate
     end
 
     attr_reader :start_date, :end_date
 
-    def initialize(start_date)
-      @start_date = Date.parse(start_date)
-      @end_date = @start_date + 6
+    def initialize(start_date, end_date)
+      @start_date = start_date
+      @end_date = end_date
     end
 
     def generate


### PR DESCRIPTION
Instead of passing a command line argument to the generator for the
date, have the generator work out what the dates should be for last
week. If you're trying to produce one ahead of time, you can pass the
optional `--current` argument to generate the post for the current
week.

/cc @JPrause 