### PR TITLE
Add AWS EC2 and GCE images to download page

### DIFF
--- a/site/_data/download_types.yaml
+++ b/site/_data/download_types.yaml
@@ -1,3 +1,17 @@
+- name: Amazon AWS EC2
+  download_platform: ec2
+  ext: vhd
+  size_stable: 3.3 GB
+  size_pre: 3.3 GB
+  size_devel: 3.7 GB
+
+- name: Google Cloud Platform
+  download_platform: gce
+  ext: tar.gz
+  size_stable: 1.0 GB
+  size_pre: 1.0 GB
+  size_devel: 1.3 GB
+
 - name: Microsoft Azure
   download_platform: azure
   ext: vhd

--- a/site/download/index.md
+++ b/site/download/index.md
@@ -21,7 +21,11 @@ title: Download ManageIQ
     </tr>
     {% for type in site.data.download_types %}
     <tr>
+      {% if type.download_platform == 'gce' %}
+      <td><a href="https://console.cloud.google.com/storage/browser/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
+      {% else %}
       <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
+      {% endif %}
       <td>{{ type.download_platform }}</td>
       <td>{{ type.size_stable }}</td>
     </tr>


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq.org/issues/464
(Didn't add the 'direct link' mentioned in https://github.com/ManageIQ/manageiq.org/issues/464 as Vagrant doesn't have it either...)

Marking as WIP as `-devel` links for EC2/GCE nightly builds (e.g. http://releases.manageiq.org/manageiq-ec2-devel.vhd) don't exist yet. Not sure how/where that's done.

/cc @Fryguy 
