### PR TITLE
Make lwimiq publication date current/next tuesday

### DIFF
--- a/lib/miq/lwimiq.rb
+++ b/lib/miq/lwimiq.rb
@@ -78,7 +78,7 @@ EOF
     end
 
     def publication_date
-      DateTime.now.strftime("%Y-%m-%d %H:%M:%S %Z")
+      Date.today
     end
 
     def uri_for(repo)

--- a/lib/miq/lwimiq.rb
+++ b/lib/miq/lwimiq.rb
@@ -78,7 +78,7 @@ EOF
     end
 
     def publication_date
-      Date.today
+      Date.today.upto(Date.today + 6).detect(&:tuesday?)
     end
 
     def uri_for(repo)

--- a/lib/miq/lwimiq.rb
+++ b/lib/miq/lwimiq.rb
@@ -31,7 +31,7 @@ module Miq
 ---
 title: "Last Week in ManageIQ: <subtitle>"
 author: <author>
-date: #{DateTime.now.strftime("%Y-%m-%d %H:%M:%S %Z")}
+date: #{publication_date}
 comments: true
 published: true
 tags: LWIMIQ
@@ -75,6 +75,10 @@ tags: LWIMIQ
 [manageiq-providers-azure PRs merged]: #{uri_for("manageiq-providers-azure")}
 [manageiq-providers-vmware PRs merged]: #{uri_for("manageiq-providers-vmware")}
 EOF
+    end
+
+    def publication_date
+      DateTime.now.strftime("%Y-%m-%d %H:%M:%S %Z")
     end
 
     def uri_for(repo)


### PR DESCRIPTION
Also omits the time, which seems to be problematic.

@miq-bot assign @hayesr 