### PR TITLE
Use full URL for Open Graph meta tag

### DIFF
--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -5,8 +5,8 @@
 
   <title>{{ site.title | escape }}{% if page.title %} - {{ page.title | escape }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-  <meta property="og:image" content="/assets/images/logo/manageiq-logo-blue.png" />
-
+  <meta property="og:image" content="http://manageiq.org/assets/images/logo/manageiq-logo-blue.png" />
+  
   {% css main %}
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
"a full URL is needed for Open Graph (the spec does not say this explicitly, but all examples there are full URLs, and some parsers expect them)" https://meta.stackexchange.com/questions/264186/meta-should-use-a-full-url-for-its-open-graph-image