### PR TITLE
Ignoring Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _site
 .sass-cache
 .jekyll-metadata
 .env
+Gemfile.lock*
 
 dest/
 site/docs/guides


### PR DESCRIPTION
That way when a dev runs bundle install, etc they don't have to
keep ignoring Gemfile.lock when they do a git commit.