### PR TITLE
Improve lwimiq documentation

### DIFF
--- a/exe/miq
+++ b/exe/miq
@@ -112,7 +112,7 @@ module Miq
 
   class Generate < Thor
     desc "lwimiq", "Generate a LWIMIQ blog post"
-    option :current
+    option :current, :type => :boolean
     def lwimiq
       say "Generating LWIMIQ post", :green
       Lwimiq.generate(options)

--- a/exe/miq
+++ b/exe/miq
@@ -112,6 +112,14 @@ module Miq
 
   class Generate < Thor
     desc "generate lwimiq", "Generate a LWIMIQ blog post"
+    long_desc <<-LONGDESC
+      Generates a new Last Week in ManageIQ blog post
+      skeleton. Includes all the links for PRs merged in the last week
+      in the various ManageIQ repositories.
+
+      With --current option, bin/miq generate lwimiq generates links
+      based on the current week instead of the last.
+    LONGDESC
     option :current, :type => :boolean, :default => false
     def lwimiq
       say "Generating LWIMIQ post", :green

--- a/exe/miq
+++ b/exe/miq
@@ -112,7 +112,7 @@ module Miq
 
   class Generate < Thor
     desc "lwimiq", "Generate a LWIMIQ blog post"
-    option :current, :type => :boolean
+    option :current, :type => :boolean, :default => false
     def lwimiq
       say "Generating LWIMIQ post", :green
       Lwimiq.generate(options)

--- a/exe/miq
+++ b/exe/miq
@@ -111,7 +111,7 @@ module Miq
   end
 
   class Generate < Thor
-    desc "lwimiq", "Generate a LWIMIQ blog post"
+    desc "generate lwimiq", "Generate a LWIMIQ blog post"
     option :current, :type => :boolean, :default => false
     def lwimiq
       say "Generating LWIMIQ post", :green


### PR DESCRIPTION
Improves the documentation for the generator.

Before:
```
tim@tim-thinkpad:~/src/manageiq.org$ bin/miq generate help lwimiq
Usage:
  miq lwimiq

Options:
  [--current=CURRENT]  

Generate a LWIMIQ blog post
```

After:
```
tim@tim-thinkpad:~/src/manageiq.org$ bin/miq generate help lwimiq
Usage:
  miq generate lwimiq

Options:
  [--current], [--no-current]  

Description:
  Generates a new Last Week in ManageIQ blog post skeleton. Includes all the links for PRs merged in the last week in the various ManageIQ repositories.

  With --current option, bin/miq generate lwimiq generates links based on the current week instead of the last.
```