### PR TITLE
Adjust images for proper rendering on tablet/mobile

### DIFF
--- a/site/_assets/css/_triad.scss
+++ b/site/_assets/css/_triad.scss
@@ -22,7 +22,7 @@
 }
 
 .triad-logo {
-  width: 15%;
+  width: 70px;
   margin-right: 1em;
 }
 
@@ -103,6 +103,11 @@
 
   .triad-cloud {
     width: 180px;
+  }
+
+  .triad-docker {
+    padding-top: 15px;
+    width: 200px;
   }
 
   .triad-button {


### PR DESCRIPTION
This PR tweaks to styling of the "Try it!" images to render properly on tablet and mobile

Before

<img width="911" alt="screen shot 2017-07-17 at 4 46 13 pm" src="https://user-images.githubusercontent.com/1287144/28289146-8a7da56c-6b0f-11e7-8144-201c8c5e7c22.png">

<img width="748" alt="screen shot 2017-07-17 at 4 45 58 pm" src="https://user-images.githubusercontent.com/1287144/28289142-8a75400c-6b0f-11e7-85d4-f6195526f406.png">

After

<img width="927" alt="screen shot 2017-07-17 at 4 44 16 pm" src="https://user-images.githubusercontent.com/1287144/28289144-8a7a3e18-6b0f-11e7-88c2-b1998ed64f9b.png">

<img width="748" alt="screen shot 2017-07-17 at 4 44 27 pm" src="https://user-images.githubusercontent.com/1287144/28289143-8a796b96-6b0f-11e7-887f-09c8e468a9d0.png">

