### PR TITLE
Changed the provider link

### DIFF
--- a/site/docs/get-started/add-a-provider.md
+++ b/site/docs/get-started/add-a-provider.md
@@ -10,7 +10,7 @@ vSphere and OpenStack.
 
 Capabilities between providers can be different
 and evolve with time, so don’t forget to check the [support options
-document](*The link to the support options document*)
+document](https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/)
 
 ### Create a Google Cloud Platform account (if needed)
 


### PR DESCRIPTION
Changed the provider link to the documentation page "Managing Providers" (https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/)