### PR TITLE
Add Hawkular Provider to the community view

### DIFF
--- a/site/_data/github_repos.yaml
+++ b/site/_data/github_repos.yaml
@@ -28,6 +28,9 @@
 - name: manageiq-providers-lenovo
   description: ManageIQ plugin for the Lenovo XClarity provider
 
+- name: manageiq-providers-hawkular
+  description: ManageIQ plugin for the Hawkular provider
+
 - name: manageiq-api-client
   description: Ruby client library to the ManageIQ REST API
 


### PR DESCRIPTION
I add the repo of Hawkular to the community site.

![screenshot from 2017-11-02 13-15-16](https://user-images.githubusercontent.com/3019213/32325605-eaf5ffba-bfcf-11e7-85d0-8875b134da8d.png)
