### PR TITLE
Add ovirt qc2 option to download page

### DIFF
--- a/site/_data/download_types.yaml
+++ b/site/_data/download_types.yaml
@@ -8,7 +8,7 @@
 - name: Google Cloud Platform
   download_platform: gce
   ext: tar.gz
-  size_stable: 1.2 GB
+  size_stable: 1.3 GB
   size_pre: 1.1 GB
   size_devel: 1.4 GB
 
@@ -17,21 +17,21 @@
   ext: vhd
   size_stable: 4.0 GB
   size_pre: 3.6 GB
-  size_devel: 4.2 GB
+  size_devel: 4.5 GB
 
 - name: Microsoft SCVMM
   download_platform: hyperv
   ext: vhd
   size_stable: 4.0 GB
   size_pre: 3.6 GB
-  size_devel: 4.2 GB
+  size_devel: 4.6 GB
 
 - name: OpenStack
   download_platform: openstack
   ext: qc2
-  size_stable: 1.5 GB
+  size_stable: 1.4 GB
   size_pre: 1.2 GB
-  size_devel: 1.6 GB
+  size_devel: 1.8 GB
 
 - name: oVirt
   download_platform: ovirt
@@ -43,11 +43,18 @@
 - name: QEmu/KVM
   download_platform: openstack
   ext: qc2
-  size_stable: 1.5 GB
+  size_stable: 1.4 GB
+  size_pre: 1.2 GB
+  size_devel: 1.8 GB
+
+- name: Red Hat Virtualization (4.0 and newer)
+  download_platform: ovirt
+  ext: qc2
+  size_stable: 1.4 GB
   size_pre: 1.2 GB
   size_devel: 1.6 GB
 
-- name: Red Hat Enterprise Virtualization
+- name: Red Hat Enterprise Virtualization (3.6 and earlier)
   download_platform: ovirt
   ext: ova
   size_stable: 1.3 GB
@@ -59,4 +66,4 @@
   ext: ova
   size_stable: 1.3 GB
   size_pre: 1.2 GB
-  size_devel: 1.5 GB
+  size_devel: 1.7 GB

--- a/site/download/index.md
+++ b/site/download/index.md
@@ -17,7 +17,7 @@ title: Download ManageIQ
     <tr>
       <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Docker {{release.name}}', transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
       <td>docker</td>
-      <td>0.7 GB</td>
+      <td>0.8 GB</td>
     </tr>
     {% for type in site.data.download_types %}
     <tr>
@@ -95,7 +95,7 @@ title: Download ManageIQ
     <tr>
       <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Docker {{release.name}}', transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
       <td>docker</td>
-      <td>0.6 GB</td>
+      <td>0.8 GB</td>
     </tr>
     {% for type in site.data.download_types %}
     <tr>


### PR DESCRIPTION
QCOW2 appliance image is used for for RHV 4.0 and newer. Currently we only have the OVA appliance (which is for RHEV 3.6 and earlier). This PR adds the qc2 option to the download page, as well as update some of the image size information.

Addresses issue: https://github.com/ManageIQ/manageiq.org/issues/613