### PR TITLE
Remove arbitration profiles from the API menu

### DIFF
--- a/site/_data/menus/api_menu.yml
+++ b/site/_data/menus/api_menu.yml
@@ -25,8 +25,6 @@
   children:
   - title: Primary Collections
     path: "/docs/reference/latest/api/reference/collections"
-  - title: Arbitration Profiles
-    path: "/docs/reference/latest/api/reference/arbitration_profiles"
   - title: Arbitration Rules
     path: "/docs/reference/latest/api/reference/arbitration_rules"
   - title: Arbitration Settings


### PR DESCRIPTION
@epwinchell this is just a guess and it might remove the things from older releases too :disappointed: please test.