### PR TITLE
Fix code block formatting/syntax highlighting

### DIFF
--- a/site/_assets/css/_syntax-highlighting.scss
+++ b/site/_assets/css/_syntax-highlighting.scss
@@ -3,7 +3,6 @@
  */
 .highlight {
     background: #fff;
-    @extend %vertical-rhythm;
 
     .highlighter-rouge & {
       background: #eef;

--- a/site/_assets/css/_syntax-highlighting.scss
+++ b/site/_assets/css/_syntax-highlighting.scss
@@ -14,6 +14,30 @@ pre {
   }
 }
 
+// console specific colorings, dark theme
+//
+// Taken from the "Monokai Remastered" theme
+$console_bg: #222;
+
+@mixin console_color_0      { color: #1a1a1a           }
+@mixin console_color_1      { color: #f4005f           }
+@mixin console_color_2      { color: #98e024           }
+@mixin console_color_3      { color: #fd971f           }
+@mixin console_color_4      { color: #9d65ff           }
+@mixin console_color_5      { @include console_color_1 }
+@mixin console_color_6      { color: #58d1eb           }
+@mixin console_color_7      { color: #c4c5b5           }
+
+@mixin console_color_0_bold { color: #625e4c;           font-weight: bold }
+@mixin console_color_1_bold { @include console_color_1; font-weight: bold }
+@mixin console_color_2_bold { @include console_color_2; font-weight: bold }
+@mixin console_color_3_bold { color: #e0d561;           font-weight: bold }
+@mixin console_color_4_bold { @include console_color_4; font-weight: bold }
+@mixin console_color_5_bold { @include console_color_5; font-weight: bold }
+@mixin console_color_6_bold { @include console_color_6; font-weight: bold }
+@mixin console_color_7_bold { color: #f6f6ef;           font-weight: bold }
+
+
 .highlight {
     background: #fff;
 
@@ -80,4 +104,17 @@ pre {
     .vg    { color: #008080 } // Name.Variable.Global
     .vi    { color: #008080 } // Name.Variable.Instance
     .il    { color: #099 } // Literal.Number.Integer.Long
+}
+
+.language-console {
+  pre code { @include console_color_7; }
+
+  &.highlighter-rouge .highlight {
+    background: $console_bg;
+  }
+
+  .w  { @include console_color_4_bold; } // Prompt
+  .nc { @include console_color_1_bold; } // Command
+  .kv { @include console_color_7_bold; } // Extra args
+  .c  { @include console_color_0_bold; } // comment
 }

--- a/site/_assets/css/_syntax-highlighting.scss
+++ b/site/_assets/css/_syntax-highlighting.scss
@@ -1,6 +1,19 @@
 /**
  * Syntax highlighting styles
  */
+
+/**
+ * bootstrap/code override
+ *
+ * Prevents codeblocks from wrapping their content, and allows them to
+ * `overflow: auto` as expected.
+ */
+pre {
+  code {
+    white-space: pre;
+  }
+}
+
 .highlight {
     background: #fff;
 

--- a/site/_assets/css/main.scss
+++ b/site/_assets/css/main.scss
@@ -62,7 +62,8 @@ $menu-level-pad: 36px;
   "off_canvas",
   "header",
   "footer",
-  "lightbox";
+  "lightbox",
+  "syntax-highlighting";
 
 // Home page
 @import

--- a/site/_posts/2017-09-21-finalizers-can-be-interrupted-from-time-to-time.md
+++ b/site/_posts/2017-09-21-finalizers-can-be-interrupted-from-time-to-time.md
@@ -17,7 +17,8 @@ it's still around in the libraries we use.
 
 Note, I even filtered out some of the results below:
 
-<pre><code style="white-space: pre">$ grep -r -E "\bTimeout.timeout\b" /Users/joerafaniello/.gem/ruby/2.4.2/gems
+```console
+$ grep -r -E "\bTimeout.timeout\b" /Users/joerafaniello/.gem/ruby/2.4.2/gems
 ruby_parser-3.10.1/lib/ruby_parser_extras.rb:                                     Timeout.timeout time do
 capybara-2.5.0/lib/capybara/server.rb:                                            Timeout.timeout(60) { @server_thread.join(0.1) until responsive? }
 dalli-2.7.6/lib/dalli/socket.rb:                                                  Timeout.timeout(options[:socket_timeout]) do
@@ -49,7 +50,7 @@ webmock-2.3.2/spec/support/network_connection.rb:                               
 
 $ grep -r -E "\bTimeout::timeout\b" /Users/joerafaniello/.gem/ruby/2.4.2/gems
 open4-1.3.4/lib/open4.rb:                                                         Timeout::timeout(timeout) do
- </code></pre>
+```
 
 Those are only gems used by ManageIQ.  I'm sure there are many other gems used by other
 projects that still use Timeout.
@@ -118,16 +119,18 @@ We ran it with ruby debug `RUBYOPT=-d`.
 
 When it worked, it looked like this:
 
-<pre><code style="white-space: pre">Exception `Timeout::Error' at /Users/joerafaniello/.rubies/ruby-2.3.4/lib/ruby/2.3.0/timeout.rb:112 - execution expired
+```console
+Exception `Timeout::Error' at /Users/joerafaniello/.rubies/ruby-2.3.4/lib/ruby/2.3.0/timeout.rb:112 - execution expired
 removing /var/folders/fq/blrz820d3qz7nm7vj8mbtfs40000gq/T/x20170906-57250-s683fs...
 done
-</code></pre>
+```
 
 When it would hang, it looked like this:
 
-<pre><code style="white-space: pre">Exception `Timeout::Error' at /Users/joerafaniello/.rubies/ruby-2.3.4/lib/ruby/2.3.0/timeout.rb:112 - execution expired
+```console
+Exception `Timeout::Error' at /Users/joerafaniello/.rubies/ruby-2.3.4/lib/ruby/2.3.0/timeout.rb:112 - execution expired
 removing /var/folders/fq/blrz820d3qz7nm7vj8mbtfs40000gq/T/x20170906-57351-jfeu6l...
-</code></pre>
+```
 
 If you're still reading, you might have noticed that `done` is missing when the
 test hangs. The `done` happens after `Tempfile` wants to [close and unlink the file here](https://github.com/ruby/ruby/blob/820605ba3c10b9f4dafc4e5d6e09765b8b31cbea/lib/tempfile.rb#L255-L257).
@@ -148,7 +151,8 @@ not something we want to troubleshoot at 5pm on a Friday.
 
 It's ok, there aren't many places that define finalizers:
 
-<pre><code style="white-space: pre">$ grep -r define_finalizer /Users/joerafaniello/.rubies/ruby-2.4.2
+```console
+$ grep -r define_finalizer /Users/joerafaniello/.rubies/ruby-2.4.2
 lib/ruby/2.4.0/cgi/session.rb:                                         ObjectSpace::define_finalizer(self, Session::callback(@dbprot))
 lib/ruby/2.4.0/drb/timeridconv.rb:                                     ObjectSpace.define_finalizer(Object.new) {on_gc}
 lib/ruby/2.4.0/tempfile.rb:                                            ObjectSpace.define_finalizer(self, Remover.new(@tmpfile))
@@ -163,7 +167,7 @@ logging-2.2.2/lib/logging.rb:                                          ObjectSpa
 tins-1.15.0/lib/tins/thread_local.rb:                                  ObjectSpace.define_finalizer(self, @@cleanup)
 vcr-3.0.3/lib/vcr/library_hooks/webmock.rb:                            ObjectSpace.define_finalizer(Thread.current, lambda {
 winrm-2.2.3/lib/winrm/shells/base.rb:                                  ObjectSpace.define_finalizer(
-</code></pre>
+```
 
 It's a small list but libraries like tempfile, concurrent-ruby, ffi, actionview,
 etc. are pretty common.  Again, this is only in the gems that ManageIQ uses.  This

--- a/site/_posts/2017-09-29-miqldap-to-sssd.md
+++ b/site/_posts/2017-09-29-miqldap-to-sssd.md
@@ -108,12 +108,12 @@ LDAPS with certificates or, after running *miqldap_to_sssd*, update the */etc/ss
 include certificates. See the LDAPS example below and the SSSD(8) man page for more information about
 certificates.
 
-<pre><code style="white-space: pre">
-miq> miqldap_to_sssd 
+```
+$ miqldap_to_sssd 
 Converting from unsecured LDAP authentication to SSSD. This is dangerous. Passwords are not encrypted
 tools/miqldap_to_sssd.rb Conversion Completed
-miq> 
-</code></pre>
+$
+```
 
 
 **miqldap_to_sssd log**
@@ -176,8 +176,8 @@ the **domain**, **bind-dn** and **bind-pwd** arguments.
 This is because, with this configuration, values for these items are not available in the appliance database.
 
 *miqldap_to_sssd* supports 7 arguments. This example uses the **domain**, **bind-dn** and **bind-pwd** arguments.
-<pre><code style="white-space: pre">
-miq> miqldap_to_sssd --help
+```console
+$ miqldap_to_sssd --help
 Usage: ruby tools/miqldap_to_sssd.rb [options]
   -d, --domain                               The domain name for the Base DN, e.g. example.com
   -b, --bind-dn                              The Bind DN, credential to use to authenticate against LDAP e.g.
@@ -187,15 +187,15 @@ Usage: ruby tools/miqldap_to_sssd.rb [options]
   -n, --only-change-userids                  normalize the userids then exit
   -s, --skip-post-conversion-userid-change   Do the MiqLdap to SSSD conversion but skip the normalizing of the userids
   -h, --help                                 Show this message
-</code></pre>
+```
 
 **Note:** The Base DN must be in "dot" form e.g.: *example.com*
-<pre><code style="white-space: pre">
-miq> miqldap_to_sssd --domain example.com --bind-dn cn=Manager,dc=example,dc=com --bind-pwd password
+```console
+$ miqldap_to_sssd --domain example.com --bind-dn cn=Manager,dc=example,dc=com --bind-pwd password
 Converting from unsecured LDAP authentication to SSSD. This is dangerous. Passwords are not encrypted
 tools/miqldap_to_sssd.rb Conversion Completed
-miq> 
-</code></pre>
+$
+```
 
 **Authentication Mode External(httpd)**
 ---------------------------------------------------------------------
@@ -247,8 +247,8 @@ with the path to the certificate file.
 Note the warning regarding the unsecured LDAP and not encrypted passwords, is not displayed because the conversion from LDAP**S**
 preserves the certificate security.
 
-<pre><code style="white-space: pre">
-miq> miqldap_to_sssd --help
+```console
+$ miqldap_to_sssd --help
 Usage: ruby tools/miqldap_to_sssd.rb [options]
   -d, --domain                               The domain name for the Base DN, e.g. example.com
   -b, --bind-dn                              The Bind DN, credential to use to authenticate against LDAP e.g.
@@ -258,13 +258,13 @@ Usage: ruby tools/miqldap_to_sssd.rb [options]
   -n, --only-change-userids                  normalize the userids then exit
   -s, --skip-post-conversion-userid-change   Do the MiqLdap to SSSD conversion but skip the normalizing of the userids
   -h, --help                                 Show this message
-</code></pre>
+```
 
-<pre><code style="white-space: pre">
-miq> miqldap_to_sssd --tls-cacert  /etc/openldap/certs/cacert.pem
+```conosle
+$ miqldap_to_sssd --tls-cacert  /etc/openldap/certs/cacert.pem
 tools/miqldap_to_sssd.rb Conversion Completed
-miq> 
-</code></pre>
+$
+```
 
 **Authentication Mode External(httpd)**
 ---------------------------------------------------------------------
@@ -281,8 +281,8 @@ The other 2 will be explained here.
 
 Again the 7 supported argument are:
 
-<pre><code style="white-space: pre">
-miq> miqldap_to_sssd --help
+```console
+$ miqldap_to_sssd --help
 Usage: ruby tools/miqldap_to_sssd.rb [options]
   -d, --domain                               The domain name for the Base DN, e.g. example.com
   -b, --bind-dn                              The Bind DN, credential to use to authenticate against LDAP e.g.
@@ -292,7 +292,7 @@ Usage: ruby tools/miqldap_to_sssd.rb [options]
   -n, --only-change-userids                  normalize the userids then exit
   -s, --skip-post-conversion-userid-change   Do the MiqLdap to SSSD conversion but skip the normalizing of the userids
   -h, --help                                 Show this message
-</code></pre>
+```
 
 As mentioned earlier :
 

--- a/site/_posts/2018-01-31-troubleshooting-auth.md
+++ b/site/_posts/2018-01-31-troubleshooting-auth.md
@@ -180,11 +180,11 @@ Be sure to include the "h" flag, as indicated below when generating the tar ball
 
 These shell commands shows how to generate the tar ball and verify it's contents:
 
-<pre><code style="white-space: pre">
-  miq_bash> cd /var/www/miq/vmdb
-  miq_bash> tar cvfzh my_log_files.tar.gz log 
-  miq_bash> tar ztvf my_log_files.tar.gz 
-</code></pre>
+```console
+$ cd /var/www/miq/vmdb
+$ tar cvfzh my_log_files.tar.gz log
+$ tar ztvf my_log_files.tar.gz
+```
 
 ## Capturing Authentication Data From ManageIQ DB
 ---------------------------------------------------------------------
@@ -193,27 +193,27 @@ The below commands can be used on the appliance where the database resides to ca
 the authentication configuration settings, group and user information from the database.
 
   + This shell command can be used to query the database for the ***authentication settings***:
-
-  <pre><code style="white-space: pre">
-  miq_bash> /var/www/miq/vmdb/bin/rails runner 'puts Settings.authentication'
-  </code></pre>
-
+    
+    ```console
+    $ /var/www/miq/vmdb/bin/rails runner 'puts Settings.authentication'
+    ```
+    
   + This shell command can be used to query the database for the list of known ***groups***:
-
+    
   + The groups returned from the IdP for users expected to be authenticated on ManageIQ must match at least one
     group reported by this command. If not one must be manually added using the ManageIQ UI.
-
-  <pre><code style="white-space: pre">
-  miq_bash> /var/www/miq/vmdb/bin/rails runner 'puts MiqGroup.pluck(:description)'
-  </code></pre>
-
+    
+    ```console
+    $ /var/www/miq/vmdb/bin/rails runner 'puts MiqGroup.pluck(:description)'
+    ```
+    
   + This shell command can be used to query the database for the list of known ***users***:
-
+    
   + ManageIQ will auto create authenticated and authorized users if **Get User Groups** from the IdP is configured on the ManageIQ Authentication page.
-
-  <pre><code style="white-space: pre">
-  miq_bash> /var/www/miq/vmdb/bin/rails runner 'puts User.pluck(:userid)'
-  </code></pre>
+    
+    ```console
+    $ /var/www/miq/vmdb/bin/rails runner 'puts User.pluck(:userid)'
+    ```
 
 ## Confirming LDAP Configuration
 ---------------------------------------------------------------------
@@ -225,88 +225,88 @@ The LDAPSEARCH(1) man page can be found by searching for ***ldapsearch*** in the
 Follow these steps to run ldapsearch.
 
   + Step 1. Get the certs from the OpenLdap Serve if using secure LDAP**S** *These commands may vary depending on how the certs are managed on the LDAP server.*
+    
+    ```console
+     # Remove any old certs
+    $ rm /etc/openldap/certs/&ast;
 
-  <pre><code style="white-space: pre">
-  # Remove any old certs
-  miq_bash> rm /etc/openldap/certs/&ast;
+     # Copy the certs from the LDAP server:
+    $ scp root@ldaphost.example.com:/etc/pki/tls/certs/cacert.pem  /etc/openldap/certs/
+    $ scp root@ldaphost.example.com:/etc/pki/tls/certs/server&ast;.pem /etc/openldap/certs/
 
-  # Copy the certs from the LDAP server:
-  miq_bash> scp root@ldaphost.example.com:/etc/pki/tls/certs/cacert.pem  /etc/openldap/certs/
-  miq_bash> scp root@ldaphost.example.com:/etc/pki/tls/certs/server&ast;.pem /etc/openldap/certs/
-
-  # Rehash the certs
-  miq_bash> /usr/sbin/cacertdir_rehash /etc/openldap/certs/
-  </code></pre>
-
+     # Rehash the certs
+    $ /usr/sbin/cacertdir_rehash /etc/openldap/certs/
+    ```
+    
   + Step 2. Update `/etc/openldap/ldap.conf` to:
-
-  Here is an example of an `ldap.conf`. *The values will vary depending on how the certs are managed on the LDAP server.*
-
-  <pre><code style="white-space: pre">
-  SASL_NOCANON    on
-  URI             https://ldaphost.example.com:636
-  BASE            dc=example,dc=com
-  TLS_REQCERT     demand
-  TLS_CACERTDIR   /etc/openldap/certs
-  TLS_CACERT      /etc/openldap/certs/cacert.pem
-  </code></pre>
-
+    
+    Here is an example of an `ldap.conf`. *The values will vary depending on how the certs are managed on the LDAP server.*
+    
+    ```console
+    SASL_NOCANON    on
+    URI             https://ldaphost.example.com:636
+    BASE            dc=example,dc=com
+    TLS_REQCERT     demand
+    TLS_CACERTDIR   /etc/openldap/certs
+    TLS_CACERT      /etc/openldap/certs/cacert.pem
+    ```
+    
   + Step 3. Verify the cert with openssl and LDAP configuration with openssl. For example:
-
-  <pre><code style="white-space: pre">
-  miq_bash> openssl s_client -connect ldaphost.example.com:636 -CAfile /etc/openldap/certs/cacert.pem
-  miq_bash> openssl s_client -showcerts -connect ldaphost.example.com:636
-  </code></pre>
-
+    
+    ```console
+    $ openssl s_client -connect ldaphost.example.com:636 -CAfile /etc/openldap/certs/cacert.pem
+    $ openssl s_client -showcerts -connect ldaphost.example.com:636
+    ```
+    
   + The flags used in the `ldapsearch` examples are:
+    
+    ```console
+    -x Use simple authentication instead of SASL.
 
-  <pre><code style="white-space: pre">
-  -x Use simple authentication instead of SASL.
+    -H ldaphost
 
-  -H ldaphost
+    -b searchbase
+       Use  searchbase  as the starting point for the search instead of the default.
 
-  -b searchbase
-     Use  searchbase  as the starting point for the search instead of the default.
+    -D binddn
+       Use the Distinguished Name binddn to bind to the LDAP directory.
+       For SASL binds, the server is expected to ignore this value.
 
-  -D binddn
-     Use the Distinguished Name binddn to bind to the LDAP directory.
-     For SASL binds, the server is expected to ignore this value.
+    -w passwd
+       Use passwd as the password for simple authentication.
 
-  -w passwd
-     Use passwd as the password for simple authentication.
-
-  -d debuglevel
-     Set the LDAP debugging level to debuglevel. ldapsearch must be compiled with
-     LDAP_DEBUG defined for this option to have any effect.
-  </code></pre>
-
+    -d debuglevel
+       Set the LDAP debugging level to debuglevel. ldapsearch must be compiled with
+       LDAP_DEBUG defined for this option to have any effect.
+    ```
+  
   + Step 4. Run non-secure `ldapsearch`
-
-  Specify `ldap` protocol and port with a binddn and password
-
-  <pre><code style="white-space: pre">
-  miq_bash> ldapsearch -x -H ldap://ldaphost.example.com:389  -b "dc=example,dc=com"  -D "cn=Manager,dc=example,dc=com" -w password
-  </code></pre>
-
+    
+    Specify `ldap` protocol and port with a binddn and password
+    
+    ```console
+    $ ldapsearch -x -H ldap://ldaphost.example.com:389  -b "dc=example,dc=com"  -D "cn=Manager,dc=example,dc=com" -w password
+    ```
+  
   + Step 5. Run `ldapsearch` using Transport Layer Security ***TLS***
-
-  Specify `ldap` protocol and port but do not specify binddn or password will result in a TLS exchange.
-
-  <pre><code style="white-space: pre">
-  miq_bash> ldapsearch -x -H ldap://ldaphost.example.com:389  -b "dc=example,dc=com"
-  </code></pre>
-
+    
+    Specify `ldap` protocol and port but do not specify binddn or password will result in a TLS exchange.
+    
+    ```console
+    $ ldapsearch -x -H ldap://ldaphost.example.com:389  -b "dc=example,dc=com"
+    ```
+  
   + Step 6. Run `ldapsearch` using Secure Sockets Layer ***SSL***
-
-  Specify `ldaps` protocol and port will result in SSL exchange.
-
-  <pre><code style="white-space: pre">
-  miq_bash> ldapsearch -x -H ldaps://ldaphost.example.com:636  -b "dc=example,dc=com"
-  </code></pre>
-
-  The `-d` flag can be used to produce debugging information.
-
-  Diagnosing `ldapsearch` failures is beyond the scope of this blog.
+    
+    Specify `ldaps` protocol and port will result in SSL exchange.
+    
+    ```console
+    $ ldapsearch -x -H ldaps://ldaphost.example.com:636  -b "dc=example,dc=com"
+    ```
+    
+    The `-d` flag can be used to produce debugging information.
+    
+    Diagnosing `ldapsearch` failures is beyond the scope of this blog.
 
 ## Confirming SSSD Configuration
 ---------------------------------------------------------------------
@@ -326,19 +326,19 @@ Follow these steps to run ldapsearch.
 This ***dbus-send / GetUserAttr*** command can be used to confirm all of the user attributes used
 by ManageIQ authentication are correctly provided by the underlying technology.
 
-<pre><code style="white-space: pre">
-  miq_bash> dbus-send \
+```console
+$ dbus-send \
   --print-reply \
   --system \
   --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe org.freedesktop.sssd.infopipe.GetUserAttr \
   string:mshiffrin array:string:mail,givenname,sn,displayname,domainname
-</code></pre>
+```
 
 The output from the above ***dbus-send / GetUserAttr*** command should look similar to the following:
 
 `Note:` The ***domainname*** attribute became available in the Gaprindashvili release and is not available in older releases of ManageIQ.
 
-<pre><code style="white-space: pre">
+```console
 method return sender=:1.40 -> dest=:1.48 reply_serial=2
    array [
       dict entry(
@@ -372,29 +372,29 @@ method return sender=:1.40 -> dest=:1.48 reply_serial=2
             ]
       )
    ]
-</code></pre>
+```
 
 ### ***dbus-send / GetUserGroups***
 
 This ***dbus-send / GetUserGroups*** command can be used to confirm all of the user's groups are correctly provided by the underlying technology.
 
-<pre><code style="white-space: pre">
-  miq_bash> dbus-send \
+```console
+$ dbus-send \
   --print-reply \
   --system \
   --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe org.freedesktop.sssd.infopipe.GetUserGroups \
   string:mshiffrin
-</code></pre>
+```
 
 The output from the above ***dbus-send / GetUserAttr*** command should look similar to the following:
 
-<pre><code style="white-space: pre">
+```console
 method return sender=:1.40 -> dest=:1.189 reply_serial=2
    array [
       string "evmgroup-super_administrator"
       string "gs-group"
    ]
-</code></pre>
+```
 
 + If these dbus-send commands fail to return the required information the SSSD configuration must be diagnosed and fixed before attempting to use ManageIQ.
   See: [**Diagnosing Failed dbus Commands**](#diagnosing-failed-dbus-commands)
@@ -406,28 +406,29 @@ If the ***dbus-send*** commands described in section [**Confirming SSSD Configur
 do not succeed the SSSD configuration can be diagnosed by doing the following:
 
   + Add ***debug_level=9*** to each of the sections of the SSSD configuration file: ***/etc/sssd/sssd.conf***
-
+    
   + Restart the sssd service and confirm it is running.
-
-  If it does not restart there could be errors in the `/etd/sssd/sssd.conf` file that need to be addressed.
-
-  <pre><code style="white-space: pre">
-  miq_bash> systemctl restart sssd.service
-  miq_bash> systemctl status sssd.service
-  </code></pre>
-
+    
+    If it does not restart there could be errors in the `/etd/sssd/sssd.conf` file that need to be addressed.
+    
+    ```console
+    $ systemctl restart sssd.service
+    $ systemctl status sssd.service
+    ```
+    
   + `Note:` If updates are done to the  ***/etc/sssd/sssd.conf*** file and not immediately seen when authenticating,
      then clean the SSSD cache as follows and restart the service:
-
-  <pre><code style="white-space: pre">
-  miq_bash> sss_cache -E
-  </code></pre>
-
+    
+    ```console
+    $ sss_cache -E
+    ```
+    
   + tail the sssd log files
-  <pre><code style="white-space: pre">
-  tail -f /var/log/sssd/&ast;.log
-  </code></pre>
-
+    
+    ```console
+    $ tail -f /var/log/sssd/&ast;.log
+    ```
+    
   + Rerun the ***dbus-send*** commands described in section [**Confirming SSSD configuration**](#confirming-sssd-configuration)
 
 ## Adding Groups In ManageIQ


### PR DESCRIPTION
Issue
-----

There were two main issues that are being addressed:

* Code blocks were doing "word wrap" by default
  - This was brought in a CSS rule from `"bootstrap/code"`
  - It has been worked around previously using `<pre><code style="white-space: pre">` directly (looks ugly...)
* Syntax highlighting was being handled in the markup, but wasn't highlighted by the CSS
  - Seems to have been introduced a while ago when patternfly was removed from this repo


The Fix
-------

To resolve the above:

* Included the `_syntax-highlighter.scss` into the `main.scss` file
* A updated rule was added to override the `"bootstrap/code"` addition we don't want (second commit)

In addition:

* Added a `console` specific color theme to add emphasis to terminal based code snippets (third commit)
  - This commit is optional if you don't like it or it clashes for some reason (though I think it makes things pretty :blossom: )
* Updated posts that were using the `<pre><code style="...">` hack to use regular markdown code blocks. (fourth commit)
  - Also made a few other formatting updates to around these changes to what I assumed were the original intent
  - This commit is optional if we don't want to update these posts, or the original authors don't want me touching their stuff


Screenshots
-----------

### Code highlighting

Taken from:

http://manageiq.org/blog/2018/02/the-pathname-to-discovering-a-memory-leak-in-ruby/

#### Before

<img width="681" alt="screen shot 2018-07-11 at 4 01 04 pm" src="https://user-images.githubusercontent.com/314014/42604728-dee4cce4-8539-11e8-8610-d58033b41879.png">

#### After

<img width="689" alt="screen shot 2018-07-11 at 4 01 16 pm" src="https://user-images.githubusercontent.com/314014/42604730-defa60ae-8539-11e8-99e2-84a1ba6a22ef.png">


### Console blocks

Taken from:

http://manageiq.org/blog/2018/02/the-pathname-to-discovering-a-memory-leak-in-ruby/

#### Before

<img width="688" alt="screen shot 2018-07-11 at 4 00 51 pm" src="https://user-images.githubusercontent.com/314014/42604789-26b38704-853a-11e8-8f8d-79c98185743b.png">

#### After

<img width="683" alt="screen shot 2018-07-11 at 4 00 43 pm" src="https://user-images.githubusercontent.com/314014/42604788-26a2cab8-853a-11e8-93c3-22612329328d.png">


### Formatting updates to the "Troubleshooting Auth" post

http://manageiq.org/blog/2018/01/troubleshooting-auth/

Things to note:
  - ```` ```console```` is now being used instead of `<pre><code style="...">` blocks
  - Code blocks now line up with the list elements (minor white space changes)
  - Prompt has been changed from `miq_bash>` to simply `$` for... #Reasons™... (sorry Joe V.)
  - Comments had to have a 1 space indent
    - `rouge`, the syntax highlighter, is currently SUPER out of date, so it's current `ShellSession` lexer currently assumes `$` or `#` are prompts, and can't differentiate between `#` being a comment and it being a prompt.  Fixed in newer versions, but wasn't going to do update that gem here just for that (might cause other stability issues).

This post had the largest number of these type of changes, but similar changes were also done in the others as well (mostly the first couple bullet points though).

#### Before

<img width="714" alt="screen shot 2018-07-11 at 5 06 17 pm" src="https://user-images.githubusercontent.com/314014/42604841-657ee46a-853a-11e8-8fb7-f10a59be7247.png">

#### After

<img width="684" alt="screen shot 2018-07-11 at 5 05 46 pm" src="https://user-images.githubusercontent.com/314014/42604840-656bd49c-853a-11e8-8c59-8be1c72fa9fd.png">