### PR TITLE
Update vagrant box to hammer for pre-release

### DIFF
--- a/site/download/index.md
+++ b/site/download/index.md
@@ -70,7 +70,7 @@ title: Download ManageIQ
     </tr>
     {% endfor %}
     <tr>
-      <td><a href="https://app.vagrantup.com/manageiq/boxes/gaprindashvili" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Vagrant {{release.name}}', transport: 'beacon' });">Vagrant</a></td>
+      <td><a href="https://app.vagrantup.com/manageiq/boxes/hammer" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Vagrant {{release.name}}', transport: 'beacon' });">Vagrant</a></td>
       <td>vagrant</td>
       <td>1.1 GB</td>
     </tr>


### PR DESCRIPTION
vagrant box name didn't get updated when we started `hammer` pre-release, so updating now..

@cybette @JPrause  Currently, index.md has docker and vagrant release specific data in the file (docker image size, vagrant image size and box name).

I think the index page should be refactored so everything about releases (branch name, box name, etc.) live in `site/_data/releases.yaml` and everything about image details live in `site/_data/download_types.yaml`

Otherwise it will be easy to miss an update, like this time...

