### PR TITLE
Fix the iframe rendering for the build stats on the Community page

### DIFF
--- a/site/community.md
+++ b/site/community.md
@@ -10,7 +10,8 @@ ManageIQ is open source and open for contributions. There are many ways to get i
 
 <div class="row">
   <div class="col-md-6">
-    <br /><script type='text/javascript' src='https://www.openhub.net/p/manageiq/widgets/project_basic_stats?format=js'></script>
+    <br />
+    <iframe src="https://www.openhub.net/p/manageiq/widgets/project_basic_stats" scrolling="no" marginHeight="0" marginWidth="0" style="height: 225px; width: 350px; border: none"></iframe>
   </div>
 
   <div class="col-md-6">


### PR DESCRIPTION
**Before:**
![screenshot from 2018-12-17 16-45-02](https://user-images.githubusercontent.com/649130/50097891-259e1380-021b-11e9-93c9-0c00ff983493.png)

**After:**
![screenshot from 2018-12-17 16-42-56](https://user-images.githubusercontent.com/649130/50097900-29319a80-021b-11e9-90cb-da175eb7ff1b.png)

Fixes #690