### PR TITLE
Create new Events page

### DIFF
--- a/site/community.md
+++ b/site/community.md
@@ -31,6 +31,10 @@ ManageIQ is open source and open for contributions. There are many ways to get i
       <button class="js-gitter-toggle-chat-button" data-gitter-toggle-chat-state="false">Close Chat</button></p>
       <br />
       <p>Check out the <a href="/blog/">ManageIQ blog</a> and comment on the latest community news.</p>
+
+      <h3>Community Events</h3>
+      <p>Browse the <a href="/community/events">Events Calendar</a> and learn where you can meet up with other members of the community.
+      </p>
   </div>
 
   <div class="col-md-6">
@@ -64,129 +68,11 @@ ManageIQ is open source and open for contributions. There are many ways to get i
   </div>
 </div>
 
----
-
 ## Let's Meet
 
 Here are some opportunities to meet with members of the community to learn and share about ManageIQ, whether online or in person, at international conferences or local meetups. Materials from past events will be made available here as well.
 
 ### Upcoming Events
-
-<div class="row">
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/foss-north2019.png" alt="Foss-north Gothenburg 2019" /></p>
-    <p><a href="https://foss-north.se/2019/">Foss-north</a> <br /> April 8-9, 2019 in Gothenburg, Sweden</p>
-  </div>
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/rhsummit2019.png" alt="Red Hat Summit Boston 2019" /></p>
-    <p><a href="https://www.redhat.com/en/summit/2019">
-    Red Hat Summit</a> <br /> May 7-9, 2019 in Boston, MA, USA</p>
-  </div>
-
-</div>
-
-### Past Events
-
-<div class="row">
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/viennarbmeetup41.png" alt="vienna.rb #41" /></p>
-    <p><a href="https://www.meetup.com/vienna-rb/events/239689512/">Ruby User Group Vienna meetup #41</a> <br /> June 8, 2017 in Vienna, Austria</p>
-  </div>
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/ansiblefestlnd17.png" alt="AnsibleFest London 2017" /></p>
-    <p><a href="https://www.ansible.com/ansiblefest/london">#AnsibleFest London 2017</a> <br /> June 22, 2017 in London, UK</p>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/osdc2017.png" alt="OSDC 2017" /></p>
-    <p><a href="https://www.netways.de/en/events/osdc/archive/osdc2017/talks/">OSDC 2017</a> <br /> May 16-18, 2017 in Berlin, Germany</p>
-  </div>
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/openexpo2017.png" alt="OpenExpo 2017" /></p>
-    <p><a href="http://www.openexpo.es/en/">OpenExpo 2017</a> <br /> June 1, 2017 in Madrid, Spain</p>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/rhsummit2017.png" alt="RHSUMMIT 2017" /></p>
-    <p><a href="https://www.redhat.com/en/summit/2017">Red Hat Summit 2017</a> <br /> May 2-4, 2017 in Boston, MA</p>
-  </div>
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/oscal17.png" alt="OSCAL 2017" /></p>
-    <p><a href="https://oscal.openlabs.cc">OSCAL 2017</a> <br /> May 13-14, 2017 in Tirana, Albania</p>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/fossasia2017.png" alt="FOSSASIA 2017" /></p>
-    <p><a href="http://2017.fossasia.org/">FOSSASIA 2017</a> <br /> March 17-19, 2017 in Singapore</p>
-  </div>
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/kubeconeu2017.png" alt="CloudNativeCon + KubeCon 2017" /></p>
-    <p><a href="http://events.linuxfoundation.org/events/cloudnativecon-and-kubecon-europe">CloudNativeCon + KubeCon 2017</a> <br /> March 29-30, 2017 in Berlin, Germany</p>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/fosdem2017.png" alt="FOSDEM 2017" /></p>
-    <p><a href="https://fosdem.org/2017/">FOSDEM 2017</a> <br /> February 4-5, 2017 in Brussels, Belgium</p>
-  </div>
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/devconfcz2017.png" alt="DevConf.CZ 2017" /></p>
-    <p><a href="https://devconf.cz/">DevConf.CZ 2017</a> <br /> January 27-29, 2017 in Brno, Czech Republic</p>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/gdgdevfestmadrid2016.png" alt="GDG DevFest Madrid 2016" /></p>
-    <p><a href="https://gdgmadrid.com/">GDG DevFest Madrid 2016</a> <br /> December 2-3, 2016 in Madrid, Spain</p>
-    <p>Speaker: <a href="https://twitter.com/sergioocon">Sergio Ocón</a> <br /> Topic:
-    <a href="https://gdgmadrid.com/schedule/day1?sessionId=101">Collaborating in ManageIQ</a></p>
-  </div>
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/nluug2016.png" alt="NLUUG Fall Conference 2016" /></p>
-    <p><a href="https://nluug.nl/activiteiten/events/nj16/index.html">NLUUG Fall Conference 2016</a>
-    <br /> November 17, 2016 in Utrecht, The Netherlands</p>
-    <p>Speaker: <a href="https://twitter.com/mhulsman66">Mike Hulsman</a> <br /> Topic:
-    <a href="https://nluug.nl/activiteiten/events/nj16/abstracts/ab10.html">ManageIQ: Control your Cloud and Virtualization Services</a><br />
-    Recap: <a href="https://twitter.com/i/moments/799390447361728512">Tweets,</a>
-    <a href="http://ftp.nluug.nl/video/nluug/2016-11-17_nj16/zaal-1/1_ManageIQ_control_your_cloud_and_virtualisation_services_-_Mike_Hulsman.webm">video</a></p>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/rubyconf2016.png" alt="RubyConf 2016" /></p>
-    <p><a href="http://rubyconf.org/">RubyConf 2016</a> <br /> November 10-12, 2016 in Cincinnati, OH</p>
-    <p>Speaker: <a href="https://twitter.com/chrisarcand">Chris Arcand</a> <br /> Topic:
-    <a href="http://rubyconf.org/program#prop_46">Deletion Driven Development: Code to delete code!</a><br />
-    Recap: <a href="https://speakerdeck.com/chrisarcand/deletion-driven-development-code-to-delete-code-north-american-edition">Slides,</a>
-    <a href="http://confreaks.tv/videos/rubyconf2016-deletion-driven-development-code-to-delete-code">video</a></p>
-  </div>
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/kubecon2016.png" alt="KubeCon 2016" /></p>
-    <p><a href="http://events.linuxfoundation.org/events/cloudnativecon">KubeCon 2016</a> <br /> November 8-9, 2016 in Seattle, WA</p>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/miqsummit2016.png" alt="ManageIQ Design Summit 2016" /></p>
-    <p><a href="http://miqsummit2016.eventbrite.com/">ManageIQ Design Summit 2016</a> <br /> June 6-7, 2016 in Mahwah, NJ</p>
-    <p>Recap: <a href="/blog/2016/06/presentation-slides-and-demo-videos-from-manageiq-design-summit/">Slides,</a>
-    <a href="/blog/2016/07/manageiq-design-summit-2016-recap-with-photos-and-videos/">videos and photos</a></p>
-  </div>
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/miqsummit2014.png" alt="ManageIQ Design Summit 2014" /></p>
-    <p><a href="http://miqdevsummit14.eventbrite.com/">ManageIQ Design Summit 2014</a> <br /> Oct 7-8, 2014 in Mahwah, NJ</p>
-  </div>
-</div>
 
 ### Sprint reviews
 

--- a/site/events.md
+++ b/site/events.md
@@ -1,0 +1,130 @@
+---
+layout: page
+title: Events
+permalink: /community/events/
+---
+
+## Let's Meet
+
+Here are some opportunities to meet with members of the community to learn and share about ManageIQ, whether online or in person, at international conferences or local meetups. Materials from past events will be made available here as well.
+
+### Upcoming Events
+
+<div class="row">
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/rhsummit2019.png" alt="Red Hat Summit Boston 2019" /></p>
+    <p><a href="https://www.redhat.com/en/summit/2019">
+    Red Hat Summit</a> <br /> May 7-9, 2019 in Boston, MA, USA</p>
+  </div>
+</div>
+
+### Past Events
+
+<div class="row">
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/foss-north2019.png" alt="Foss-north Gothenburg 2019" /></p>
+    <p><a href="https://foss-north.se/2019/">Foss-north</a> <br /> April 8-9, 2019 in Gothenburg, Sweden</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/viennarbmeetup41.png" alt="vienna.rb #41" /></p>
+    <p><a href="https://www.meetup.com/vienna-rb/events/239689512/">Ruby User Group Vienna meetup #41</a> <br /> June 8, 2017 in Vienna, Austria</p>
+  </div>
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/ansiblefestlnd17.png" alt="AnsibleFest London 2017" /></p>
+    <p><a href="https://www.ansible.com/ansiblefest/london">#AnsibleFest London 2017</a> <br /> June 22, 2017 in London, UK</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/osdc2017.png" alt="OSDC 2017" /></p>
+    <p><a href="https://www.netways.de/en/events/osdc/archive/osdc2017/talks/">OSDC 2017</a> <br /> May 16-18, 2017 in Berlin, Germany</p>
+  </div>
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/openexpo2017.png" alt="OpenExpo 2017" /></p>
+    <p><a href="http://www.openexpo.es/en/">OpenExpo 2017</a> <br /> June 1, 2017 in Madrid, Spain</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/rhsummit2017.png" alt="RHSUMMIT 2017" /></p>
+    <p><a href="https://www.redhat.com/en/summit/2017">Red Hat Summit 2017</a> <br /> May 2-4, 2017 in Boston, MA</p>
+  </div>
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/oscal17.png" alt="OSCAL 2017" /></p>
+    <p><a href="https://oscal.openlabs.cc">OSCAL 2017</a> <br /> May 13-14, 2017 in Tirana, Albania</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/fossasia2017.png" alt="FOSSASIA 2017" /></p>
+    <p><a href="http://2017.fossasia.org/">FOSSASIA 2017</a> <br /> March 17-19, 2017 in Singapore</p>
+  </div>
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/kubeconeu2017.png" alt="CloudNativeCon + KubeCon 2017" /></p>
+    <p><a href="http://events.linuxfoundation.org/events/cloudnativecon-and-kubecon-europe">CloudNativeCon + KubeCon 2017</a> <br /> March 29-30, 2017 in Berlin, Germany</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/fosdem2017.png" alt="FOSDEM 2017" /></p>
+    <p><a href="https://fosdem.org/2017/">FOSDEM 2017</a> <br /> February 4-5, 2017 in Brussels, Belgium</p>
+  </div>
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/devconfcz2017.png" alt="DevConf.CZ 2017" /></p>
+    <p><a href="https://devconf.cz/">DevConf.CZ 2017</a> <br /> January 27-29, 2017 in Brno, Czech Republic</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/gdgdevfestmadrid2016.png" alt="GDG DevFest Madrid 2016" /></p>
+    <p><a href="https://gdgmadrid.com/">GDG DevFest Madrid 2016</a> <br /> December 2-3, 2016 in Madrid, Spain</p>
+    <p>Speaker: <a href="https://twitter.com/sergioocon">Sergio Ocón</a> <br /> Topic:
+    <a href="https://gdgmadrid.com/schedule/day1?sessionId=101">Collaborating in ManageIQ</a></p>
+  </div>
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/nluug2016.png" alt="NLUUG Fall Conference 2016" /></p>
+    <p><a href="https://nluug.nl/activiteiten/events/nj16/index.html">NLUUG Fall Conference 2016</a>
+    <br /> November 17, 2016 in Utrecht, The Netherlands</p>
+    <p>Speaker: <a href="https://twitter.com/mhulsman66">Mike Hulsman</a> <br /> Topic:
+    <a href="https://nluug.nl/activiteiten/events/nj16/abstracts/ab10.html">ManageIQ: Control your Cloud and Virtualization Services</a><br />
+    Recap: <a href="https://twitter.com/i/moments/799390447361728512">Tweets,</a>
+    <a href="http://ftp.nluug.nl/video/nluug/2016-11-17_nj16/zaal-1/1_ManageIQ_control_your_cloud_and_virtualisation_services_-_Mike_Hulsman.webm">video</a></p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/rubyconf2016.png" alt="RubyConf 2016" /></p>
+    <p><a href="http://rubyconf.org/">RubyConf 2016</a> <br /> November 10-12, 2016 in Cincinnati, OH</p>
+    <p>Speaker: <a href="https://twitter.com/chrisarcand">Chris Arcand</a> <br /> Topic:
+    <a href="http://rubyconf.org/program#prop_46">Deletion Driven Development: Code to delete code!</a><br />
+    Recap: <a href="https://speakerdeck.com/chrisarcand/deletion-driven-development-code-to-delete-code-north-american-edition">Slides,</a>
+    <a href="http://confreaks.tv/videos/rubyconf2016-deletion-driven-development-code-to-delete-code">video</a></p>
+  </div>
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/kubecon2016.png" alt="KubeCon 2016" /></p>
+    <p><a href="http://events.linuxfoundation.org/events/cloudnativecon">KubeCon 2016</a> <br /> November 8-9, 2016 in Seattle, WA</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/miqsummit2016.png" alt="ManageIQ Design Summit 2016" /></p>
+    <p><a href="http://miqsummit2016.eventbrite.com/">ManageIQ Design Summit 2016</a> <br /> June 6-7, 2016 in Mahwah, NJ</p>
+    <p>Recap: <a href="/blog/2016/06/presentation-slides-and-demo-videos-from-manageiq-design-summit/">Slides,</a>
+    <a href="/blog/2016/07/manageiq-design-summit-2016-recap-with-photos-and-videos/">videos and photos</a></p>
+  </div>
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/miqsummit2014.png" alt="ManageIQ Design Summit 2014" /></p>
+    <p><a href="http://miqdevsummit14.eventbrite.com/">ManageIQ Design Summit 2014</a> <br /> Oct 7-8, 2014 in Mahwah, NJ</p>
+  </div>
+</div>
+


### PR DESCRIPTION
This PR moves the existing Events section from The Community page to a new Events page.

Related issue: https://github.com/ManageIQ/manageiq.org/issues/705

<img width="606" alt="screen shot 2019-01-22 at 2 18 08 pm" src="https://user-images.githubusercontent.com/1287144/51559771-d28a3280-1e50-11e9-94ea-3ea7fe6b2c9b.png">

<img width="1221" alt="Screen Shot 2019-04-23 at 9 34 35 AM" src="https://user-images.githubusercontent.com/1287144/56585060-1228fd80-65ab-11e9-9dbc-ac4b98f3e6e3.png">

