### PR TITLE
Responsive redesign of blog section

### DIFF
--- a/site/_assets/css/_blog.scss
+++ b/site/_assets/css/_blog.scss
@@ -21,17 +21,12 @@
   border-bottom: 1px solid lighten($heading-line, 10%);
 }
 
-.blog_container {
-  margin: 1em 1em 12em;
-  display: flex;
-}
-
 .blog_link {
   width: 100%;
 }
 
 .blog_header {
-  margin: 1em;
+  padding: 2em 0;
 
   h1 {
     margin: 0;
@@ -40,10 +35,6 @@
 }
 
 .pagination-container {
-  display: none;
-}
-
-.blog_side {
   display: none;
 }
 
@@ -56,35 +47,15 @@
 }
 
 @media only screen and (min-width: #{$bp-desk0}) {
-  .blog {
-    padding: 6em 0 12em;
-  }
 
   .blog_header {
-    max-width: 64em;
-    padding: 2em 0;
-    margin: 0 auto;
-
     h1 {
       font-size: 20px;
     }
   }
 
-  .blog_container {
-    max-width: 64em;
-    margin: 0 auto;
-  }
-
   .blog_main {
-    width: 44em;
-
     border-right: 1px solid lighten($heading-line, 10%);
-    margin-right: 2em;
-  }
-
-  .blog_side {
-    display: block;
-    width: (64em - 48);
   }
 
   .blog_side-group {

--- a/site/_assets/css/_off_canvas.scss
+++ b/site/_assets/css/_off_canvas.scss
@@ -42,6 +42,7 @@ main, .site-header .brand-logo {
   display: block;
   padding: 1em;
   color: #fff;
+  
 }
 
 @media only screen and (min-width: #{$bp-desk0}) {

--- a/site/_assets/css/main.scss
+++ b/site/_assets/css/main.scss
@@ -19,18 +19,12 @@ $font-size-base: 16px;
  */
 html {
   font-size: 62.5%;
+  overflow-x: hidden; // deals with off-canvas issue
 }
 
 // Breakpoints, mobile first
-$bp-mobl-s: 320px;
-$bp-mobl-m: 375px;
-$bp-mobl-l: 425px;
 
-$bp-tabl: 768px;
-
-$bp-desk0: 880px;
-$bp-desk1: 1200px;
-$bp-fourk: 2500px;
+$bp-desk0: 768px;
 
 // Home Grid vars
 $hg-gutter-width: 30px;

--- a/site/_layouts/blog_month.html
+++ b/site/_layouts/blog_month.html
@@ -3,17 +3,23 @@ layout: default
 ---
 
 <div class="blog blog_year">
-  <header class="blog_header">
-    <h1>{{ page.title }}, {{ page.year }}</h1>
-  </header>
-
-  <div class="blog_container">
-    <div class="blog_main">
-      {% include post_list.html posts=page.posts css="month_archive" %}
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-12 col-sm-10">
+        <header class="blog_header">
+          <h1>
+            {{ page.title }}
+          </h1>
+        </header>
+      </div>
     </div>
-
-    <div class="blog_side">
-      {% include blog/side.html %}
+    <div class="row">
+      <div class="col-xs-12 col-sm-10 blog_main">
+        {% include post_list.html posts=page.posts css="month_archive" %}
+      </div>
+    
+        {% include blog/side.html %}
+      </div>
     </div>
   </div>
 </div>

--- a/site/_layouts/blog_year.html
+++ b/site/_layouts/blog_year.html
@@ -3,22 +3,30 @@ layout: default
 ---
 
 <div class="blog blog_year">
-  <header class="blog_header">
-    <h1>{{ page.title }}</h1>
-  </header>
-
-  <div class="blog_container">
-    <div class="blog_main">
-      {% if page.months %}
-        {% for group in page.months %}
-          <h2 class="archive_month_title">{{ group.title }}</h2>
-          {% include post_list.html posts=group.posts css="month_archive" %}
-        {% endfor %}
-      {% endif %}
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-12 col-sm-10">
+        <header class="blog_header">
+          <h1>
+            {{ page.title }}
+          </h1>
+        </header>
+      </div>
     </div>
+    <div class="row">
+      <div class="col-xs-12 col-sm-10 blog_main">
+        {% if page.months %}
+          {% for group in page.months %}
+            <h2 class="archive_month_title">{{ group.title }}</h2>
+            {% include post_list.html posts=group.posts css="month_archive" %}
+          {% endfor %}
+        {% endif %}
+      </div>
 
-    <div class="blog_side">
-      {% include blog/side.html %}
+      <div class="col-xs-12 col-sm-2 blog_side">
+        {% include blog/side.html %}
+      </div>
+
     </div>
   </div>
 </div>

--- a/site/_layouts/post.html
+++ b/site/_layouts/post.html
@@ -3,44 +3,56 @@ layout: default
 ---
 
 <div class="blog">
-  <div class="blog_container">
-    <div class="blog_main">
-      <article class="post" itemscope itemtype="http://schema.org/BlogPosting">
-        <header class="post-header">
-          <h1 class="post-title" itemprop="name headline">{{ page.title }}</h1>
-
-          <div class="post-meta">
-            <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
-              {{ page.date | date: "%b %-d, %Y" }}
-            </time>
-
-            {% if page.author %}
-            <span itemprop="author" itemscope itemtype="http://schema.org/Person">
-              by
-              <i itemprop="name">
-                {{ page.author }}
-              </i>
-            </span>
-            {% endif %}
-
-            <ul class="post-tags">
-              {% for tag in page.tags %}
-              <li>
-                <a href="/blog/tags/{{ tag }}">{{ tag }}</a>
-              </li>
-              {% endfor %}
-            </ul>
-          </div>
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-12 col-sm-10">
+        <header class="blog_header">
+          <h1>
+            ManageIQ Blog
+          </h1>
         </header>
-
-        <div class="post-content" itemprop="articleBody">
-          {{ content }}
-        </div>
-      </article>
+      </div>
     </div>
+    <div class="row"> 
+      <div class="col-xs-12 col-sm-10 blog_main">
+        <article class="post" itemscope itemtype="http://schema.org/BlogPosting">
+          <header class="post-header">
+            <h1 class="page-title" itemprop="name headline">{{ page.title }}</h1>
 
-    <div class="blog_side">
-      {% include blog/side.html %}
+            <div class="post-meta">
+              <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+                {{ page.date | date: "%b %-d, %Y" }}
+              </time>
+
+              {% if page.author %}
+              <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+                by
+                <i itemprop="name">
+                  {{ page.author }}
+                </i>
+              </span>
+              {% endif %}
+
+              <ul class="post-tags">
+                {% for tag in page.tags %}
+                <li>
+                  <a href="/blog/tags/{{ tag }}">{{ tag }}</a>
+                </li>
+                {% endfor %}
+              </ul>
+            </div>
+          </header>
+
+          <div class="post-content" itemprop="articleBody">
+            {{ content }}
+          </div>
+        </article>
+      </div>
+
+      <div class="col-xs-12 col-sm-2 blog_side">
+          {% include blog/side.html %}
+      </div>
+
     </div>
   </div>
 </div>

--- a/site/_layouts/tag_index.html
+++ b/site/_layouts/tag_index.html
@@ -3,29 +3,35 @@ layout: default
 ---
 
 <div class="blog tag_index">
-  <header class="blog_header">
-    <h1>Tagged with {{ page.title }}</h1>
-  </header>
-
-  <div class="blog_container">
-    <div class="blog_main">
-      <div class="tag_index posts">
-        {% for post in page.pages %}
-        <article class="post_excerpt">
-          <header class="post-header">
-            <h1><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h1>
-          </header>
-
-          <div class="post-content">
-            {{ post.excerpt }}
-          </div>
-        </article>
-        {% endfor %}
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-12 col-sm-10">
+        <header class="blog_header">
+          <h1>
+            ManageIQ Blog
+          </h1>
+           <p><br><i>Tagged with {{ page.title }}</i></p>
+        </header>
       </div>
     </div>
-
-    <div class="blog_side">
-      {% include blog/side.html %}
+    <div class="row">
+      <div class="col-xs-12 col-sm-10 blog_main">
+        <div class="tag_index posts">
+          {% for post in page.pages %}
+            <article class="post_excerpt">
+              <header class="post-header">
+                <h1><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h1>
+              </header>
+              <div class="post-content">
+                {{ post.excerpt }}
+              </div>
+            </article>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="col-xs-12 col-sm-2 blog_side">
+        {% include blog/side.html %}
+      </div>
     </div>
   </div>
 </div>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -4,34 +4,38 @@ title: ManageIQ Blog
 ---
 
 <div class="blog">
-  <header class="blog_header">
-    <h1>{{ page.title }}</h1>
-  </header>
-
-  <div class="blog_container">
-    <div class="blog_main">
-      {% for post in paginator.posts %}
-      <article class="post_excerpt">
-        <header class="post-header">
-          <h1><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h1>
-          <div class="post-meta">
-            <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">
-              {{ post.date | date: "%b %-d, %Y" }}
-            </time>
-          </div>
+  <div class="container blog_container">
+    <div class="row">
+      <div class="col-xs-12 col-sm-10">
+        <header class="blog_header">
+          <h1>
+            {{ page.title }}
+          </h1>
         </header>
-
-        <div class="post-content">
-          {{ post.excerpt }}
-        </div>
-      </article>
-      {% endfor %}
-
-      {% include blog/pagination.html %}
+      </div>
     </div>
-
-    <div class="blog_side">
-      {% include blog/side.html %}
+    <div class="row">  
+      <div class="col-xs-12 col-sm-10 blog_main">
+        {% for post in paginator.posts %}
+        <article class="post_excerpt">
+          <header class="post-header">
+            <h1><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h1>
+            <div class="post-meta">
+              <time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">
+                {{ post.date | date: "%b %-d, %Y" }}
+              </time>
+            </div>
+          </header>
+          <div class="post-content">
+            {{ post.excerpt }}
+          </div>
+        </article>
+        {% endfor %}
+        {% include blog/pagination.html %}
+      </div>
+      <div class="col-xs-12 col-sm-2 blog_side">
+        {% include blog/side.html %}
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR redesigns the blog section of the website to use the bootstrap 3 grid system.  Right-menu items are now accessible at the bottom of the mobile layout rather than being invisible.

Issue : #378

Old (fixed layout)
<img width="1687" alt="screen shot 2019-01-30 at 10 15 36 am" src="https://user-images.githubusercontent.com/1287144/51991011-31b2fd00-2478-11e9-9d69-dd8e02d9a4ac.png">

New (fluid layout)
<img width="1682" alt="screen shot 2019-01-30 at 10 15 47 am" src="https://user-images.githubusercontent.com/1287144/51991015-324b9380-2478-11e9-9636-e2c2afa0ff52.png">

Old (completely missing menu in mobile mode)
<img width="728" alt="screen shot 2019-01-30 at 10 21 51 am" src="https://user-images.githubusercontent.com/1287144/51991370-f9f88500-2478-11e9-9fe3-65e7141df801.png">

New
<img width="727" alt="screen shot 2019-01-30 at 10 22 01 am" src="https://user-images.githubusercontent.com/1287144/51991371-f9f88500-2478-11e9-93f5-3af748c2842c.png">
