### PR TITLE
Add OpenID-connect to User reference menu so it pulls in the content

### DIFF
--- a/site/_data/menus/ref_menu_hammer.yml
+++ b/site/_data/menus/ref_menu_hammer.yml
@@ -56,6 +56,8 @@ authentication:
       path: "/docs/reference/hammer/auth/ldap"
     - title: SAML
       path: "/docs/reference/hammer/auth/saml"
+    - title: OpenID-Connect
+      path: "/docs/reference/hammer/auth/openid_connect"
 
 integration:
   title: Integration

--- a/site/_data/menus/ref_menu_latest.yml
+++ b/site/_data/menus/ref_menu_latest.yml
@@ -56,6 +56,8 @@ authentication:
       path: "/docs/reference/latest/auth/ldap"
     - title: SAML
       path: "/docs/reference/latest/auth/saml"
+    - title: OpenID-Connect
+      path: "/docs/reference/latest/auth/openid_connect"
 
 integration:
   title: Integration


### PR DESCRIPTION
New reference page introduced in Hammer, it has already been built and is [available online](http://manageiq.org/docs/reference/hammer/auth/openid_connect), but the menu item is missing. 

@jvlcek please check

@epwinchell please merge if everything looks ok.

Thanks!