### PR TITLE
Do not generate branch_path for documentation items that don't exist

### DIFF
--- a/lib/miq/ref_page.rb
+++ b/lib/miq/ref_page.rb
@@ -47,7 +47,9 @@ module Miq
     def branch_paths
       Miq.doc_branches.each_with_object({}) do |branch, hsh|
         branch = "latest" if branch == "master"
-        hsh[branch.to_s] = branch_path_for(branch)
+        path = branch_path_for(branch)
+        next unless File.exist?(File.join("site", path))
+        hsh[branch.to_s] = path
       end
     end
 


### PR DESCRIPTION
Not uglier than the rest of the code around it :tornado: 