### PR TITLE
Dev menu update

### DIFF
--- a/site/_data/menus/guides_menu.yml
+++ b/site/_data/menus/guides_menu.yml
@@ -22,6 +22,8 @@ children:
     path: "/docs/guides/developer_setup/minimal_mode"
   - title: Running Test Suites
     path: "/docs/guides/developer_setup/running_test_suites"
+  - title: Interactive debugging
+    path: "/docs/guides/developer_setup/debugging"
 
 - title: External Auth
   children:


### PR DESCRIPTION
This PR adds "Debugging" to the Developer Setup menu in guides

<img width="866" alt="Screen Shot 2019-03-19 at 10 51 36 AM" src="https://user-images.githubusercontent.com/1287144/54616743-89142900-4a36-11e9-85fd-1afb954b0d46.png">
