### PR TITLE
Drop the latest folder when retrieving docs to allow to overwrite

### DIFF
--- a/lib/miq/ref_docs.rb
+++ b/lib/miq/ref_docs.rb
@@ -87,6 +87,7 @@ module Miq
           rsync_copy(branch)
         end
 
+        shell "rm -rf #{dst_dir}/latest"
         shell "mv #{dst_dir}/master #{dst_dir}/latest"
       else
         logger.error "Reference docs source directory not present."


### PR DESCRIPTION
When calling the `mv` to an existing destination, it doesn't merge the files. Therefore, we first have to drop the old folder so we can pull in the new changes.

It might caused bugs in the website, not sure about it. But this is definitely *The Right Way&trade;*