### PR TITLE
Update ruby version to 2.4 to match the container we're using

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- '2.3.8'
+- '2.4'
 sudo: false
 cache: bundler
 script: bundle exec exe/miq build all


### PR DESCRIPTION
Ruby 2.3 is getting EOL in a few days and we're using 2.4 in the container that runs the website anyway...