### PR TITLE
Calendar update

### DIFF
--- a/site/community.md
+++ b/site/community.md
@@ -72,8 +72,6 @@ ManageIQ is open source and open for contributions. There are many ways to get i
 
 Here are some opportunities to meet with members of the community to learn and share about ManageIQ, whether online or in person, at international conferences or local meetups. Materials from past events will be made available here as well.
 
-### Upcoming Events
-
 ### Sprint reviews
 
 There is a ManageIQ Sprint review every 2 weeks open to the community. To join the online video conference, please use this [Bluejeans link](https://bluejeans.com/4409197730/).

--- a/site/events.md
+++ b/site/events.md
@@ -8,22 +8,17 @@ permalink: /community/events/
 
 Here are some opportunities to meet with members of the community to learn and share about ManageIQ, whether online or in person, at international conferences or local meetups. Materials from past events will be made available here as well.
 
-### Upcoming Events
-
-<div class="row">
-  <div class="col-md-6">
-    <p><img src="/assets/images/events/rhsummit2019.png" alt="Red Hat Summit Boston 2019" /></p>
-    <p><a href="https://www.redhat.com/en/summit/2019">
-    Red Hat Summit</a> <br /> May 7-9, 2019 in Boston, MA, USA</p>
-  </div>
-</div>
-
 ### Past Events
 
 <div class="row">
   <div class="col-md-6">
     <p><img src="/assets/images/events/foss-north2019.png" alt="Foss-north Gothenburg 2019" /></p>
     <p><a href="https://foss-north.se/2019/">Foss-north</a> <br /> April 8-9, 2019 in Gothenburg, Sweden</p>
+  </div>
+  <div class="col-md-6">
+    <p><img src="/assets/images/events/rhsummit2019.png" alt="Red Hat Summit Boston 2019" /></p>
+    <p><a href="https://www.redhat.com/en/summit/2019">
+    Red Hat Summit</a> <br /> May 7-9, 2019 in Boston, MA, USA</p>
   </div>
 </div>
 


### PR DESCRIPTION
This PR moves all events under "Past Events"  and removes an old "Upcoming Events" title from  the community page