### PR TITLE
Add deployment to manageiq.github.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
-rvm:
-- '2.4'
-sudo: false
+rvm: '2.5'
 cache: bundler
 script: bundle exec exe/miq build all
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: curl -sSL https://raw.githubusercontent.com/ManageIQ/manageiq.github.io/build/trigger.sh | bash -s
+  on:
+    branch: master


### PR DESCRIPTION
This PR adds a deployment step to Travis so that a successful merged build will kick a website rebuild via the newer GH pages based manageiq.github.io (which will eventually become manageiq.org)

Note this repo is not going away...it will still be the source for the website and manageiq.github.io will be the dest.

@bdunne Please review