### PR TITLE
Drop OVA for oVirt/RHV

### DIFF
--- a/site/_data/download_types.yaml
+++ b/site/_data/download_types.yaml
@@ -42,10 +42,10 @@
 
 - name: oVirt
   download_platform: ovirt
-  ext: ova
-  size_stable: 2.1 GB
-  size_pre: 2.0 GB
-  size_devel: 2.4 GB
+  ext: qc2
+  size_stable: 2.4 GB
+  size_pre: 2.2 GB
+  size_devel: 2.6 GB
 
 - name: QEmu/KVM
   download_platform: openstack

--- a/site/_data/download_types.yaml
+++ b/site/_data/download_types.yaml
@@ -54,19 +54,12 @@
   size_pre: 2.2 GB
   size_devel: 2.6 GB
 
-- name: Red Hat Virtualization (4.0 and newer)
+- name: Red Hat Virtualization
   download_platform: ovirt
   ext: qc2
   size_stable: 2.4 GB
   size_pre: 2.2 GB
   size_devel: 2.6 GB
-
-- name: Red Hat Enterprise Virtualization (3.6 and earlier)
-  download_platform: ovirt
-  ext: ova
-  size_stable: 2.1 GB
-  size_pre: 2.0 GB
-  size_devel: 2.4 GB
 
 - name: VMware vSphere
   download_platform: vsphere


### PR DESCRIPTION
Dropping OVA for oVirt/RHV as the currently supported versions of oVirt/RHV (4.x) all support qcow2. Note, our documentation for RHV talks about using qc2 image and not ova.

Related PR: https://github.com/ManageIQ/manageiq-appliance-build/pull/354


