### PR TITLE
Improve bundler caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 rvm: '2.5'
-cache: bundler
+env:
+  global:
+  - BUNDLE_PATH=${TRAVIS_BUILD_DIR}/vendor/bundle
+cache:
+  directories:
+  - ${BUNDLE_PATH}
 script: bundle exec exe/miq build all
 deploy:
   provider: script

--- a/lib/miq/executor.rb
+++ b/lib/miq/executor.rb
@@ -49,8 +49,13 @@ module Miq
     # we need a clean Bundler env.
     # FIXME: This is might be a bit naive
     def run_cmd_with_bundle_env(cmd, clean)
+      # Honor BUNDLE_PATH env var so that gems can go into a common location
+      env = ENV["BUNDLE_PATH"] ? {"BUNDLE_PATH" => ENV["BUNDLE_PATH"]} : {}
+
       if clean || (cmd =~ /cd\ /)
-        Bundler.clean_system(cmd)
+        Bundler.with_clean_env do
+          system(env, cmd)
+        end
       else
         system(cmd)
       end


### PR DESCRIPTION
@bdunne Please review.

This will allow the build code to honor BUNDLE_PATH, which can be a place for all gems from manageiq.org and manageiq_docs to go into, thus making caching work more effectively.  This also allows the manageiq.github.io build to do the same.