### PR TITLE
Add Vagrant download for nightly and refactoring

### DIFF
--- a/site/_data/download_types.yaml
+++ b/site/_data/download_types.yaml
@@ -5,6 +5,12 @@
   size_pre: 2.1 GB
   size_devel: 2.5 GB
 
+- name: Docker
+  download_platform: docker
+  size_stable: 1.4 GB
+  size_pre: 1.4 GB
+  size_devel: 1.4 GB
+
 - name: Google Cloud Platform
   download_platform: gce
   ext: tar.gz
@@ -60,6 +66,13 @@
   size_stable: 2.4 GB
   size_pre: 2.2 GB
   size_devel: 2.6 GB
+
+- name: Vagrant
+  download_platform: vagrant
+  ext: box
+  size_stable: 2.2 GB
+  size_pre: 2.4 GB
+  size_devel: 2.4 GB
 
 - name: VMware vSphere
   download_platform: vsphere

--- a/site/download/index.md
+++ b/site/download/index.md
@@ -14,27 +14,21 @@ title: Download ManageIQ
       <th>Format</th>
       <th>Size</th>
     </tr>
-    <tr>
-      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Docker {{release.name}}', transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
-      <td>docker</td>
-      <td>1.4 GB</td>
-    </tr>
     {% for type in site.data.download_types %}
     <tr>
-      {% if type.download_platform == 'gce' %}
-      <td><a href="https://console.cloud.google.com/storage/browser/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
+      {% if type.download_platform == 'docker' %}
+        <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: '{{ type.name }} {{release.name}}', transport: 'beacon' });">{{ type.name }} (tag {{release.tag}})</a></td>
+      {% elsif type.download_platform == 'gce' %}
+        <td><a href="https://console.cloud.google.com/storage/browser/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
+      {% elsif type.download_platform == 'vagrant' %}
+        <td><a href="https://app.vagrantup.com/manageiq/boxes/ivanchuk" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: '{{ type.name }} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
       {% else %}
-      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
+        <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
       {% endif %}
       <td>{{ type.download_platform }}</td>
       <td>{{ type.size_stable }}</td>
     </tr>
     {% endfor %}
-    <tr>
-      <td><a href="https://app.vagrantup.com/manageiq/boxes/ivanchuk" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Vagrant {{release.name}}', transport: 'beacon' });">Vagrant</a></td>
-      <td>vagrant</td>
-      <td>2.2 GB</td>
-    </tr>
   </table>
 </div>
 
@@ -53,27 +47,21 @@ title: Download ManageIQ
       <th>Format</th>
       <th>Size</th>
     </tr>
-    <tr>
-      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Docker {{release.name}}', transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
-      <td>docker</td>
-      <td>0.8 GB</td>
-    </tr> 
     {% for type in site.data.download_types %}
     <tr>
-      {% if type.download_platform == 'gce' %}
-      <td><a href="https://console.cloud.google.com/storage/browser/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
+      {% if type.download_platform == 'docker' %}
+        <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: '{{ type.name }} {{release.name}}', transport: 'beacon' });">{{ type.name }} (tag {{release.tag}})</a></td>
+      {% elsif type.download_platform == 'gce' %}
+        <td><a href="https://console.cloud.google.com/storage/browser/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
+      {% elsif type.download_platform == 'vagrant' %}
+        <td><a href="https://app.vagrantup.com/manageiq/boxes/ivanchuk" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: '{{ type.name }} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
       {% else %}
-      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
+        <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
       {% endif %}
       <td>{{ type.download_platform }}</td>
       <td>{{ type.size_pre }}</td>
     </tr>
     {% endfor %}
-    <tr>
-      <td><a href="https://app.vagrantup.com/manageiq/boxes/ivanchuk" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Vagrant {{release.name}}', transport: 'beacon' });">Vagrant</a></td>
-      <td>vagrant</td>
-      <td>2.1 GB</td>
-    </tr>
   </table>
 </div>
 
@@ -92,14 +80,13 @@ title: Download ManageIQ
       <th>Format</th>
       <th>Size</th>
     </tr>
-    <tr>
-      <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: 'Docker {{release.name}}', transport: 'beacon' });">Docker (tag {{release.tag}})</a></td>
-      <td>docker</td>
-      <td>1.3 GB</td>
-    </tr>
     {% for type in site.data.download_types %}
     <tr>
-      <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
+      {% if type.download_platform == 'docker' %}
+        <td><a href="https://hub.docker.com/r/manageiq/manageiq/" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'outbound', eventLabel: '{{ type.name }} {{release.name}}', transport: 'beacon' });">{{ type.name }} (tag {{release.tag}})</a></td>
+      {% else %}
+        <td><a href="http://releases.manageiq.org/manageiq-{{type.download_platform}}-{{release.filename}}.{{type.ext}}" onClick="ga('send', 'event', { eventCategory: 'Appliance', eventAction: 'download', eventLabel: '{{type.name}} {{release.name}}', transport: 'beacon' });">{{ type.name }}</a></td>
+      {% endif %}
       <td>{{ type.download_platform }}</td>
       <td>{{ type.size_devel }}</td>
     </tr>

--- a/site/download/index.md
+++ b/site/download/index.md
@@ -3,17 +3,21 @@ layout: page
 title: Download ManageIQ
 ---
 
+{% capture column_title %}
+    <tr>
+      <th>Appliance</th>
+      <th>Format</th>
+      <th>Size</th>
+    </tr>
+{% endcapture %}
+
 {% assign release = site.data.releases["stable"] %}
 
 ### Current stable release ({{ release.name }})
 
 <div class="table-responsive">
   <table class="table table-bordered table-hover">
-    <tr>
-      <th>Appliance</th>
-      <th>Format</th>
-      <th>Size</th>
-    </tr>
+    {{ column_title }}
     {% for type in site.data.download_types %}
     <tr>
       {% if type.download_platform == 'docker' %}
@@ -42,11 +46,7 @@ title: Download ManageIQ
 
 <div class="table-responsive">
   <table class="table table-bordered table-hover">
-    <tr>
-      <th>Appliance</th>
-      <th>Format</th>
-      <th>Size</th>
-    </tr>
+    {{ column_title }}
     {% for type in site.data.download_types %}
     <tr>
       {% if type.download_platform == 'docker' %}
@@ -75,11 +75,7 @@ title: Download ManageIQ
 
 <div class="table-responsive">
   <table class="table table-bordered table-hover">
-    <tr>
-      <th>Appliance</th>
-      <th>Format</th>
-      <th>Size</th>
-    </tr>
+    {{ column_title }}
     {% for type in site.data.download_types %}
     <tr>
       {% if type.download_platform == 'docker' %}


### PR DESCRIPTION
Added Vagrant in download 'nightly' section, linking to releases.manageiq.org since we don't publish nightly images to vagrantup (just like GCE).

Also refactored the docker/vagrant list so it uses the same format as others , and dry'ed up column title.