### PR TITLE
Reorganize Community page

### DIFF
--- a/site/community.md
+++ b/site/community.md
@@ -10,71 +10,51 @@ ManageIQ is open source and open for contributions. There are many ways to get i
 
 <div class="row">
   <div class="col-md-6">
+    <h3>Connect</h3>
+    <p>Find us in your favorite social channel so you can be in the loop with announcements and happenings.</p>
+    <ul style="list-style-type: none;">
+      <li><a href="https://twitter.com/manageiq" class="twitter-follow-button" data-show-screen-name="false" data-show-count="false">Follow @manageiq</a><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script> <a href="https://twitter.com/manageiq">@manageiq on Twitter</a></li>
+      <li><iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&width=100&layout=button&action=like&size=small&show_faces=true&share=false&height=65&appId" width="65" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe> <a href="https://www.facebook.com/manageiq">ManageIQ on Facebook</a></li>
+      <li><script type="IN/FollowCompany" data-id="56141"></script> <a href="https://www.linkedin.com/company/manageiq">ManageIQ on LinkedIn</a></li>
+
+      <li><a title="View ManageIQ's profile on slideshare" href="http://www.slideshare.net/ManageIQ"><img src="//public.slidesharecdn.com/images/logo/linkedin-ss/SS_Logo_Black_Large.png?ebc847ff10" width="90" height="25" alt="SlideShare" /></a> <a href="http://www.slideshare.net/ManageIQ/presentations"> Sprint Review slides</a></li>
+
+     <li><div class="g-ytsubscribe" data-channel="ManageIQvideo" data-layout="default" data-count="hidden"></div> <a href="https://www.youtube.com/user/ManageIQVideo">Event & Sprint Review videos</a></li>
+    </ul>
+
+    <h3>Collaborate</h3>
+    <p>Access the source code and developer guides to get going. Refer to the above engagement channels if you need some assistance!</p>
+    <ul>
+      <li> <a href="https://github.com/manageiq/manageiq">Main ManageIQ GitHub repo</a> <a class="github-button" href="https://github.com/manageiq/manageiq" data-icon="octicon-star" aria-label="Star manageiq/manageiq on GitHub">Star</a> <a class="github-button" href="https://github.com/manageiq/manageiq/fork" data-icon="octicon-repo-forked" aria-label="Fork manageiq/manageiq on GitHub">Fork</a></li>
+      <li><a href="https://github.com/orgs/ManageIQ/people">Members in ManageIQ community on GitHub</a></li>
+      <li> <a href="https://github.com/manageiq">All repos under ManageIQ</a> <a class="github-button" href="https://github.com/manageiq" aria-label="Follow @manageiq on GitHub">Follow @manageiq</a></li>
+      <li> <a href="/docs/guides/architecture">Developer Guides</a></li>
+    </ul>
+    <p>In addition, you don't have to be a developer to be able to contribute. Filing <a href="https://github.com/ManageIQ/manageiq/issues/new">issues/bugs</a> is a great way to help. The ManageIQ project also welcomes <a href="https://translate.zanata.org/project/view/manageiq">translations</a>!</p>
+  </div>
+
+
+  <div class="col-md-6">
+    <h3>Discuss</h3>
+    <p>Join the active ManageIQ community on <a href="http://talk.manageiq.org/">ManageIQ Talk forum</a> with your questions and discussions, or chat with us anytime on <a href="https://gitter.im/ManageIQ/manageiq">Gitter</a> (sign in with your GitHub account).</p>
+    <p><button class="js-gitter-toggle-chat-button" data-gitter-toggle-chat-state="true">Open Chat</button>
+    <button class="js-gitter-toggle-chat-button" data-gitter-toggle-chat-state="false">Close Chat</button></p>
     <br />
-    <iframe src="https://www.openhub.net/p/manageiq/widgets/project_basic_stats" scrolling="no" marginHeight="0" marginWidth="0" style="height: 225px; width: 350px; border: none"></iframe>
-  </div>
+    <p>Check out the <a href="/blog/">ManageIQ blog</a> and comment on the latest community news.</p>
 
-  <div class="col-md-6">
-    <br /><p><a href="https://github.com/orgs/ManageIQ/people">Members in ManageIQ community</a></p>
-    <p>Contributors to the ManageIQ repositories:</p>
-    {% for repo in site.data.github_repos %}
-    <small>&#9823;&nbsp;<a href="https://github.com/ManageIQ/{{repo.name}}/graphs/contributors" title="{{repo.description}}">{{repo.name}}</a></small>
-    {% endfor %}
-  </div>
+    <h3>Community Events</h3>
+    <p>Browse the <a href="/community/events">Events Calendar</a> and learn where you can meet up with other members of the community.
+    </p>
+
+    <h3>Sprint reviews</h3>
+
+    <p>There is a ManageIQ Sprint review every 2 weeks open to the community. To join the online video conference, please use this <a href="https://bluejeans.com/598633815/">Bluejeans link</a>.</p>
+
+    <p>You can import the <a href="https://calendar.google.com/calendar/embed?src=contact%40manageiq.org">ManageIQ community calendar</a> to be notified about ManageIQ events and Sprint reviews.</p>
+
+    <p>Check out <a href="https://docs.google.com/document/d/1bbBXy9OLOowZ2rYcAehLaW5ccSeSOHC-OxfONEGQ9mE/edit?usp=sharing">Sprint Reviews Artifacts</a> for links to previous Sprint Reviews and Slide Decks.</p>
+  </div> 
 </div>
-
-<div class="row">
-  <div class="col-md-6">
-      <h3>Discuss</h3>
-      <p>Join the active ManageIQ community on <a href="http://talk.manageiq.org/">ManageIQ Talk forum</a> with your questions and discussions, or chat with us anytime on <a href="https://gitter.im/ManageIQ/manageiq">Gitter</a> (sign in with your GitHub account).</p>
-      <p><button class="js-gitter-toggle-chat-button" data-gitter-toggle-chat-state="true">Open Chat</button>
-      <button class="js-gitter-toggle-chat-button" data-gitter-toggle-chat-state="false">Close Chat</button></p>
-      <br />
-      <p>Check out the <a href="/blog/">ManageIQ blog</a> and comment on the latest community news.</p>
-
-      <h3>Community Events</h3>
-      <p>Browse the <a href="/community/events">Events Calendar</a> and learn where you can meet up with other members of the community.
-      </p>
-  </div>
-
-  <div class="col-md-6">
-      <h3>Connect</h3>
-      <p>Find us in your favorite social channel so you can be in the loop with announcements and happenings.</p>
-      <ul>
-        <li><a href="https://twitter.com/manageiq" class="twitter-follow-button" data-show-screen-name="false" data-show-count="false">Follow @manageiq</a><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script> <a href="https://twitter.com/manageiq">@manageiq on Twitter</a></li>
-        <li><iframe src="https://www.facebook.com/plugins/like.php?href=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&width=100&layout=button&action=like&size=small&show_faces=true&share=false&height=65&appId" width="65" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe> <a href="https://www.facebook.com/manageiq">ManageIQ on Facebook</a></li>
-        <li><script type="IN/FollowCompany" data-id="56141"></script> <a href="https://www.linkedin.com/company/manageiq">ManageIQ on LinkedIn</a></li>
-      </ul>
-      <p>Peruse and enjoy the <a title="View ManageIQ's profile on slideshare" href="http://www.slideshare.net/ManageIQ"><img src="//public.slidesharecdn.com/b/images/badge120X33px_lite.png" width="90" height="25" alt="SlideShare" /></a> <a href="http://www.slideshare.net/ManageIQ/presentations">slides</a> and <div class="g-ytsubscribe" data-channel="ManageIQvideo" data-layout="default" data-count="hidden"></div> <a href="https://www.youtube.com/user/ManageIQVideo">recordings</a> from events and Sprint reviews.</p>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-6">
-      <h3>Develop</h3>
-      <p>Access the source code and developer guides to get going. Refer to the above engagement channels if you need some assistance!</p>
-      <ul>
-        <li> <a href="https://github.com/manageiq/manageiq">Main ManageIQ GitHub repo</a> <a class="github-button" href="https://github.com/manageiq/manageiq" data-icon="octicon-star" aria-label="Star manageiq/manageiq on GitHub">Star</a> <a class="github-button" href="https://github.com/manageiq/manageiq/fork" data-icon="octicon-repo-forked" aria-label="Fork manageiq/manageiq on GitHub">Fork</a></li>
-        <li> <a href="https://github.com/manageiq">All repos under ManageIQ</a> <a class="github-button" href="https://github.com/manageiq" aria-label="Follow @manageiq on GitHub">Follow @manageiq</a></li>
-        <li> <a href="/docs/guides/architecture">Developer Guides</a></li>
-      </ul>
-  </div>
-
-  <div class="col-md-6">
-      <h3>Collaborate</h3>
-      <p>The <a href="https://depot.manageiq.org/">ManageIQ Depot</a> is a place for sharing and downloading extensions such as policies and reports.</p>
-      <p>In addition, you don't have to be a developer to be able to contribute. Filing <a href="https://github.com/ManageIQ/manageiq/issues/new">issues/bugs</a> is a great way to help. The ManageIQ project also welcomes <a href="https://translate.zanata.org/project/view/manageiq">translations</a>!</p>
-  </div>
-</div>
-
-
-### Sprint reviews
-
-There is a ManageIQ Sprint review every 2 weeks open to the community. To join the online video conference, please use this [Bluejeans link](https://bluejeans.com/598633815/).
-
-You can import the [ManageIQ community calendar](https://calendar.google.com/calendar/embed?src=contact%40manageiq.org) to be notified about ManageIQ events and Sprint reviews.
-
-Check out [Sprint Reviews Artifacts](https://docs.google.com/document/d/1bbBXy9OLOowZ2rYcAehLaW5ccSeSOHC-OxfONEGQ9mE/edit?usp=sharing) for links to previous Sprint Reviews and Slide Decks.
 
 <script>
   ((window.gitter = {}).chat = {}).options = {


### PR DESCRIPTION
This PR updates and reorganizes the Community page with the following changes:

- remove the ManageIQ Depot link
- rename "Develop" to "Collaborate"
- remove the list of individual repos, in favor of the "All repos under ManageIQ" link  in the Collaborate section.
- delete the  Open Hub graphic
- rebalance the layout

Issue: https://github.com/ManageIQ/manageiq.org/issues/786
Issue: https://github.com/ManageIQ/manageiq.org/issues/788
Issue: https://github.com/ManageIQ/manageiq.org/issues/789

Old 
<img width="629" alt="Screen Shot 2020-01-24 at 10 25 38 AM" src="https://user-images.githubusercontent.com/1287144/73080624-2086ab80-3e94-11ea-9466-6beeec917f68.png">

New
<img width="1048" alt="Screen Shot 2020-01-24 at 11 37 58 AM" src="https://user-images.githubusercontent.com/1287144/73086146-11a4f680-3e9e-11ea-92c2-8e1c09cc0494.png">


