### PR TITLE
Rename 'gems' to 'plugins'

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -5,7 +5,7 @@
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # 'jekyll serve'. If you change this file, please restart the server process.
 
-gems:
+plugins:
   - jekyll-coffeescript
   - jekyll-assets
   - jekyll-paginate


### PR DESCRIPTION
This PR renames the  'gems' configuration option to 'plugins'.