### PR TITLE
Fix md_link_converter to not strip off .md suffix for external links

### DIFF
--- a/lib/miq/md_link_converter.rb
+++ b/lib/miq/md_link_converter.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module Miq
   class MdLinkConverter
     MD_LINK = /\[([^\]]*)\]\((.*)\)/
@@ -24,10 +26,21 @@ module Miq
 
     private
 
+    def external_link?(url)
+      begin
+        uri = URI(url)
+      rescue
+        return false # in case caller does not pass in valid URL
+      end
+      return false if uri.scheme.nil? || uri.host.nil?
+      return false if uri.host.start_with?("manageiq.org") || uri.host.start_with?("www.manageiq.org")
+      return true
+    end
+
     def remove_ext(str)
       str.gsub(MD_LINK) do |link|
         title, path = link.match(MD_LINK)[1..2]
-        "[#{title}](#{path.gsub(".md", '')})"
+        external_link?(path) ? "[#{title}](#{path})" : "[#{title}](#{path.gsub(".md", '')})"
       end
     end
 

--- a/lib/miq/md_link_converter.rb
+++ b/lib/miq/md_link_converter.rb
@@ -40,7 +40,8 @@ module Miq
     def remove_ext(str)
       str.gsub(MD_LINK) do |link|
         title, path = link.match(MD_LINK)[1..2]
-        external_link?(path) ? "[#{title}](#{path})" : "[#{title}](#{path.gsub(".md", '')})"
+        path.gsub!(".md", '') unless external_link?(path)
+        "[#{title}](#{path})"
       end
     end
 

--- a/test/lib/miq/md_link_converter_test.rb
+++ b/test/lib/miq/md_link_converter_test.rb
@@ -32,4 +32,11 @@ class MdLinkConverterTest < Minitest::Test
 
     assert_equal expected, Miq::MdLinkConverter.new(original).convert
   end
+
+  def test_converting_internal_md_href
+    original = "[Title](https://manageiq.org/blah/README.md)"
+    expected = "[Title](https://manageiq.org/blah/README)"
+
+    assert_equal expected, Miq::MdLinkConverter.new(original).convert
+  end
 end

--- a/test/lib/miq/md_link_converter_test.rb
+++ b/test/lib/miq/md_link_converter_test.rb
@@ -25,4 +25,11 @@ class MdLinkConverterTest < Minitest::Test
 
     assert_equal expected, Miq::MdLinkConverter.new(original).convert
   end
+
+  def test_converting_external_md_href
+    original = "[Title](https://github.com/ManageIQ/ui-components/blob/master/README.md)"
+    expected = "[Title](https://github.com/ManageIQ/ui-components/blob/master/README.md)"
+
+    assert_equal expected, Miq::MdLinkConverter.new(original).convert
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq_docs/issues/555