### PR TITLE
Add stub for Sprint 137 so we can see Merged PRs while sprint is ongoing

### DIFF
--- a/site/_sprints/137.md
+++ b/site/_sprints/137.md
@@ -1,0 +1,9 @@
+---
+title: Sprint 137 Details
+sprint_number: 137
+slides:
+recording:
+start_date: 2020-05-12
+end_date: 2020-05-25
+review_date: 2020-05-27
+---

--- a/site/sprints/index.html
+++ b/site/sprints/index.html
@@ -41,7 +41,8 @@ title: Sprints
                 {% else %}
                     <td>NA</td>
                 {% endif %}
-                {% if sprint.url %}
+                {% assign sprints_key_for_github_data = sprint.sprint_number | prepend: "gh_" %}
+                {% if site.data.sprints[sprints_key_for_github_data] %}
                     <td><a href="{{ sprint.url }}">Details</a></td>
                 {% else %}
                     <td>NA</td>


### PR DESCRIPTION
Adding the stub exposed a bug that is addressed by this [commit](https://github.com/ManageIQ/manageiq.org/pull/841/commits/4982c05fb5cfe80c4f6d045f79c16143053dc67c) to fix sprint index to display details ONLY if GitHub data (on which the details page is based) is available