### PR TITLE
Update docs build to build from jansa branch as the latest

### DIFF
--- a/lib/miq.rb
+++ b/lib/miq.rb
@@ -81,6 +81,6 @@ module Miq
   end
 
   def self.doc_branches
-    ENV.fetch('MIQ_REF_BRANCHES', 'euwe,fine,gaprindashvili,hammer,ivanchuk,master').split(',')
+    ENV.fetch('MIQ_REF_BRANCHES', 'euwe,fine,gaprindashvili,hammer,ivanchuk,jansa').split(',')
   end
 end

--- a/lib/miq/ref_docs.rb
+++ b/lib/miq/ref_docs.rb
@@ -69,7 +69,7 @@ module Miq
       logger.info "Installing Ascii Binder"
       shell [
         "cd #{tmp_dir}",
-        "git checkout master",
+        "git checkout jansa",
         "#{bundler} install"
       ].join(" && ")
     end
@@ -88,7 +88,7 @@ module Miq
         end
 
         shell "rm -rf #{dst_dir}/latest"
-        shell "mv #{dst_dir}/master #{dst_dir}/latest"
+        shell "mv #{dst_dir}/jansa #{dst_dir}/latest"
       else
         logger.error "Reference docs source directory not present."
       end


### PR DESCRIPTION
@chessbyte Please review.  [ManageIQ/manageiq_docs@jansa](https://github.com/ManageIQ/manageiq_docs/tree/jansa) has already been synced with its master and adjusted to act as the primary build target [[1]](https://github.com/ManageIQ/manageiq_docs/commit/c3ea176668317a2db8db824eb320fa8f48c7fc83).