### PR TITLE
Part 2: adjust to rename of repo from 'ManageIQ/manageiq_docs' to 'ManageIQ/manageiq-documentation'

### DIFF
--- a/site/_data/sprints/gh_101.yaml
+++ b/site/_data/sprints/gh_101.yaml
@@ -4254,8 +4254,8 @@
       created: 1
       still_open: 1
       closed: 0
-- repo_slug: ManageIQ/manageiq_docs
-  repo_url: http://github.com/ManageIQ/manageiq_docs
+- repo_slug: ManageIQ/manageiq-documentation
+  repo_url: http://github.com/ManageIQ/manageiq-documentation
   prs:
     created:
     - 1028


### PR DESCRIPTION
Missed a file in the original [PR](https://github.com/ManageIQ/manageiq.org/pull/851)