### PR TITLE
Add --trace option to build CLI

### DIFF
--- a/exe/miq
+++ b/exe/miq
@@ -84,7 +84,7 @@ module Miq
     desc "site", "Build Jekyll site"
     def site
       say "Building Jekyll site", :green
-      Site.build
+      Site.build options[:trace]
     end
 
     desc "reference", "Build Reference Docs"
@@ -138,6 +138,7 @@ module Miq
     subcommand "update", Update
 
     desc "build <all|guides|site|reference>", "Build or process an aspect of the site"
+    option :trace, :type => :boolean, :default => false
     subcommand "build", Build
 
     desc "generate lwimiq YYYY-MM-DD", "Generate a new blog post"

--- a/lib/miq/site.rb
+++ b/lib/miq/site.rb
@@ -8,8 +8,8 @@ module Miq
       new.update
     end
 
-    def self.build
-      new.build
+    def self.build(trace = false)
+      new(trace).build
     end
 
     def self.serve
@@ -18,7 +18,7 @@ module Miq
 
     attr_reader :source_dir, :dest_dir, :branch
 
-    def initialize
+    def initialize(trace = false)
       # Where is the site directory?
       @source_dir = Miq.site_dir
 
@@ -27,6 +27,9 @@ module Miq
 
       # Which branch to pull (useful for development)
       @branch     = ENV["MIQ_SITE_BRANCH"]  || `git rev-parse --abbrev-ref HEAD`
+
+      # Tracing enabled?
+      @trace      = trace
     end
 
     def reset
@@ -38,7 +41,9 @@ module Miq
     end
 
     def build
-      shell "#{bundler} exec jekyll build -s #{source_dir} -d #{dest_dir}", clean: true
+      cmd  = "#{bundler} exec jekyll build -s #{source_dir} -d #{dest_dir}"
+      cmd += " --trace" if @trace
+      shell cmd, clean: true
     end
 
     def serve


### PR DESCRIPTION
Allows for the following:

`exe/miq build site --trace`
`exe/miq build all --trace`

This option adds --trace to the `jekyll build` command that is executed under the covers.