### PR TITLE
Change the Steampunk link

### DIFF
--- a/site/_posts/2019-12-06-introducing-new-provider-microsoft-azure-stack.md
+++ b/site/_posts/2019-12-06-introducing-new-provider-microsoft-azure-stack.md
@@ -67,4 +67,4 @@ ManageIQ](https://www.manageiq.org/download/) and connect your Microsoft Azure
 Stack to test the provider yourself.
 
 To find out more about the provider, get in touch with [XLAB
-Steampunk](https://steampunk.si) at steampunk@xlab.si.
+Steampunk](https://steampunk.si/redhat-integrations/) at steampunk@xlab.si.


### PR DESCRIPTION
As we have shifted the main page to focus more on Ansible, I wanted to update this 
blog post to our original page, showing our CloudForms integrations.