### PR TITLE
Fix the remaining link to Steampunk

### DIFF
--- a/site/_posts/2019-12-06-introducing-new-provider-microsoft-azure-stack.md
+++ b/site/_posts/2019-12-06-introducing-new-provider-microsoft-azure-stack.md
@@ -11,7 +11,7 @@ With the release of [ManageIQ
 Ivanchuk](https://www.manageiq.org/blog/2019/09/manageiq-ivanchuk-ga-announcement/),
 we are introducing new integrated provider: [Microsoft Azure
 Stack](https://azure.microsoft.com/en-us/overview/azure-stack/). Integration
-was developed by [XLAB Steampunk](https://steampunk.si/), a trusted Red Hat
+was developed by [XLAB Steampunk](https://steampunk.si/redhat-integrations/), a trusted Red Hat
 partner specialized in integrating third-party technologies with Red Hat
 CloudForms and Red Hat Ansible Automation Platform.
 


### PR DESCRIPTION
In the last update I missed the fact that there were two links. I am fixing the second one now
as the link in the page does not make too much sense.