### PR TITLE
Fix oidc api

### DIFF
--- a/site/_posts/2020-09-03-oidc-auth-api-usage.md
+++ b/site/_posts/2020-09-03-oidc-auth-api-usage.md
@@ -103,7 +103,7 @@ The bash example commands:
 # Accessing the ManageIQ API with the access_token from a JWT Token
 
    # Step 1: Request the JWT Token from the OpenID-Connect provider
-   jwt_token=$(curl -k -L --user ${user}:${password} -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password" -d "client_id=${oidc_client_id}" -d "client_secret=${oidc_client_secret}" -d "username=${user}" -d "password=${password}" ${oidc_provider_token_endpoint} )
+   jwt_token=$(curl -k -L --user ${user}:${password} -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password" -d "client_id=${oidc_client_id}" -d "client_secret=${oidc_client_secret}" -d "username=${user}" -d "password=${password}" -d "scope=openid" ${oidc_provider_token_endpoint} )
 
    # Step 2: Retrieve the access_token from the JWT
    access_token=$(echo $jwt_token | jq -r '.access_token')
@@ -134,7 +134,7 @@ The bash example commands:
 # Accessing the ManageIQ API using a ManageIQ API Auth Token
 
    # Step 1: Request the JWT Token from the OpenID-Connect provider
-   jwt_token=$(curl -k -L --user ${user}:${password} -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password" -d "client_id=${oidc_client_id}" -d "client_secret=${oidc_client_secret}" -d "username=${user}" -d "password=${password}" ${oidc_provider_token_endpoint} )
+   jwt_token=$(curl -k -L --user ${user}:${password} -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password" -d "client_id=${oidc_client_id}" -d "client_secret=${oidc_client_secret}" -d "username=${user}" -d "password=${password}" -d "scope=openid" ${oidc_provider_token_endpoint} )
 
    # Step 2: Retrieve the access_token from the JWT
    access_token=$(echo $jwt_token | jq -r '.access_token')

--- a/site/_posts/2020-09-03-oidc-auth-api-usage.md
+++ b/site/_posts/2020-09-03-oidc-auth-api-usage.md
@@ -103,7 +103,7 @@ The bash example commands:
 # Accessing the ManageIQ API with the access_token from a JWT Token
 
    # Step 1: Request the JWT Token from the OpenID-Connect provider
-   jwt_token=$(curl -k -L --user ${user}:${password} -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password" -d "client_id=${oidc_client_id}" -d "client_secret=${oidc_client_secret}" -d "username=${user}" -d "password=${password}" -d "scope=openid" ${oidc_provider_token_endpoint} )
+   jwt_token=$(curl -k -L -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password" -d "client_id=${oidc_client_id}" -d "client_secret=${oidc_client_secret}" -d "username=${user}" -d "password=${password}" -d "scope=openid" ${oidc_provider_token_endpoint} )
 
    # Step 2: Retrieve the access_token from the JWT
    access_token=$(echo $jwt_token | jq -r '.access_token')
@@ -134,7 +134,7 @@ The bash example commands:
 # Accessing the ManageIQ API using a ManageIQ API Auth Token
 
    # Step 1: Request the JWT Token from the OpenID-Connect provider
-   jwt_token=$(curl -k -L --user ${user}:${password} -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password" -d "client_id=${oidc_client_id}" -d "client_secret=${oidc_client_secret}" -d "username=${user}" -d "password=${password}" -d "scope=openid" ${oidc_provider_token_endpoint} )
+   jwt_token=$(curl -k -L -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=password" -d "client_id=${oidc_client_id}" -d "client_secret=${oidc_client_secret}" -d "username=${user}" -d "password=${password}" -d "scope=openid" ${oidc_provider_token_endpoint} )
 
    # Step 2: Retrieve the access_token from the JWT
    access_token=$(echo $jwt_token | jq -r '.access_token')

--- a/site/_posts/2020-09-03-oidc-auth-api-usage.md
+++ b/site/_posts/2020-09-03-oidc-auth-api-usage.md
@@ -109,7 +109,7 @@ The bash example commands:
    access_token=$(echo $jwt_token | jq -r '.access_token')
 
    # Step 3 (OPTIONAL) Use the access_token to do an introspection to get the details for the user associated with the JWT
-   curl -k -L --user ${oidc_client_id}:${oidc_client_secret} -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "token=${access_token}" ${oidc_auth_introspection_endpoint}
+   curl -k -L --user ${oidc_client_id}:${oidc_client_secret} -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "token=${access_token}" ${oidc_auth_introspection_endpoint} | jq
 
    # Step 4: Accessing MiQ API using the access_token in the header
    curl -L -vvv -k -X GET -H "Authorization: Bearer ${access_token}" https://${miq_server_name}/api/users | jq


### PR DESCRIPTION
When testing these instructions with IBM's Identity Access Management (IAM) provider I uncovered three issues.
These updates will ensure this blog post will correctly apply to both  IBM's Identity Access Management (IAM) provider and Keycloak.

The three issues addressed with this PR are:

1. Add parameter scope=openid which is required on IAM and OK with Keycloak
2. Remove unnecessary user flag when getting the jwt
3. Add jq to improve introspection output
