### PR TITLE
Remove dead link to 'Minimal Mode' guide

### DIFF
--- a/site/_data/menus/guides_menu.yml
+++ b/site/_data/menus/guides_menu.yml
@@ -18,8 +18,6 @@ children:
     path: "/docs/guides/developer_setup.html"
   - title: Plugins
     path: "/docs/guides/developer_setup/plugins.html"
-  - title: Minimal Mode
-    path: "/docs/guides/developer_setup/minimal_mode.html"
   - title: Running Test Suites
     path: "/docs/guides/developer_setup/running_test_suites.html"
   - title: Interactive debugging


### PR DESCRIPTION
There's a dead link to the 'Minimal Mode' guide. Looks like this was missed when removing MIQ_SPARTAN: ManageIQ/manageiq/pull/20401