### PR TITLE
Add Kubernetes and OpenShift to stable release download page

### DIFF
--- a/site/_includes/download/release_table.md
+++ b/site/_includes/download/release_table.md
@@ -8,9 +8,6 @@
       <th>MD5</th>
     </tr>
     {% for type in site.data.download_types %}
-      {% if release.type == "stable" and type.download_platform == "podified" %}
-        {% continue %}
-      {% endif %}
       {% assign data = type.download_platform | data_for: release.branch, release.tag, release.filename, type.ext %}
       {% assign url = data[0] %}
       {% assign file_size = data[1]["size"] %}


### PR DESCRIPTION
Since Jansa is the stable release now, adding kubernetes/openshift to the download page (Jansa was prerelease when they were added in https://github.com/ManageIQ/manageiq.org/pull/842).