### PR TITLE
Remove non-canonical URLs from the sitemap

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -111,6 +111,7 @@ defaults:
       layout: doc_page
       permalink: /:path/:basename
       doc_group: user
+      sitemap: false
 
   - scope:
       path: "docs/reference/fine/api"
@@ -125,6 +126,7 @@ defaults:
       layout: doc_page
       permalink: /:path/:basename
       doc_group: user
+      sitemap: false
 
   - scope:
       path: "docs/reference/euwe/api"
@@ -139,6 +141,7 @@ defaults:
       layout: doc_page
       permalink: /:path/:basename
       doc_group: user
+      sitemap: false
 
   - scope:
       path: "docs/reference/gaprindashvili/api"
@@ -153,6 +156,7 @@ defaults:
       layout: doc_page
       permalink: /:path/:basename
       doc_group: user
+      sitemap: false
 
   - scope:
       path: "docs/reference/hammer/api"
@@ -167,6 +171,7 @@ defaults:
       layout: doc_page
       permalink: /:path/:basename
       doc_group: user
+      sitemap: false
 
   - scope:
       path: "docs/reference/ivanchuk/api"
@@ -181,6 +186,7 @@ defaults:
       layout: doc_page
       permalink: /:path/:basename
       doc_group: user
+      sitemap: false
 
   - scope:
       path: "docs/reference/jansa/api"


### PR DESCRIPTION
While canonical URLs were put in the headers of these old docs, they are
ignored by google because of their presence in the sitemap.  According
to Google, all URLs in the sitemap are automatically considered
canonical, and thus are crawable/searchable.

@chessbyte Please review