### PR TITLE
exit 1 when subcommands fail

### DIFF
--- a/lib/miq/executor.rb
+++ b/lib/miq/executor.rb
@@ -49,11 +49,15 @@ module Miq
     # we need a clean Bundler env.
     # FIXME: This is might be a bit naive
     def run_cmd_with_bundle_env(cmd, clean)
-      if clean || (cmd =~ /cd\ /)
-        Bundler.clean_system(cmd)
-      else
-        system(cmd)
-      end
+      success =
+        if clean || (cmd =~ /cd\ /)
+          Bundler.clean_system(cmd)
+        else
+          system(cmd)
+        end
+
+      exit 1 unless success
+      success
     end
   end
 end


### PR DESCRIPTION
@chessbyte Please review.  Apparently the builds are failing (probably when I cut the morphy branch or so), but since the build [exits 0 on failure](https://app.travis-ci.com/github/ManageIQ/manageiq.github.io/jobs/534028134#L4461-L4462), it moves along to the deploy step and [fails _there_](https://app.travis-ci.com/github/ManageIQ/manageiq.github.io/jobs/534028134#L4477-L4495).