### PR TITLE
Dark Mode

### DIFF
--- a/site/_assets/css/_appliances.scss
+++ b/site/_assets/css/_appliances.scss
@@ -11,7 +11,7 @@
     padding: 0;
 
     span {
-      color: $text-black;
+      color: var(--color-text-primary);
     }
   }
 }

--- a/site/_assets/css/_banner.scss
+++ b/site/_assets/css/_banner.scss
@@ -21,13 +21,13 @@ $banner_height_lg: 440px;
     font-size: 24px;
     font-weight: 500;
     line-height: 1.3;
-    color: #fff;
+    color: var(--color-text-banner);
     margin: 0.5em auto;
   }
 
   h2 {
     font-size: 14px;
-    color: $blue-white;
+    color: var(--color-text-banner-2);
     margin: 0 auto;
   }
 }

--- a/site/_assets/css/_blog.scss
+++ b/site/_assets/css/_blog.scss
@@ -1,7 +1,7 @@
 // See _post.scss for .post styles
 
 .blog {
-  background-color: #fff;
+  background-color: var(--color-bg-primary);
 
   summary {
     display: list-item;
@@ -18,7 +18,7 @@
 .archive_month_title {
   font-style: italic;
   padding: 0 0 0.5em 0;
-  border-bottom: 1px solid lighten($heading-line, 10%);
+  border-bottom: 1px solid var(--color-border-primary);
 }
 
 .blog_link {
@@ -55,12 +55,12 @@
   }
 
   .blog_main {
-    border-right: 1px solid lighten($heading-line, 10%);
+    border-right: 1px solid var(--color-border-primary);
   }
 
   .blog_side-group {
     padding-bottom: 1em;
-    border-bottom: 1px solid lighten($heading-line, 10%);
+    border-bottom: 1px solid var(--color-border-primary);
     margin-bottom: 2em;
   }
 

--- a/site/_assets/css/_colors.scss
+++ b/site/_assets/css/_colors.scss
@@ -48,3 +48,18 @@ $glphy_img: url("/assets/images/logo/banner-glyph.svg") 173% 50% no-repeat;
   background: #{$glphy_img}, #{$opera_linear_grad};
   background: #{$glphy_img}, #{$linear_grad};
 }
+
+@import "themes/light";
+@import "themes/dark";
+
+@include light_theme;
+
+@media (prefers-color-scheme: dark) {
+	@include light_theme($selector: ".light-theme");
+	@include dark_theme($selector: ":root, .dark-theme");
+}
+
+@media (prefers-color-scheme: light) {
+	@include light_theme($selector: ":root, .light-theme");
+	@include dark_theme($selector: ".dark-theme");
+}

--- a/site/_assets/css/_docs.scss
+++ b/site/_assets/css/_docs.scss
@@ -1,8 +1,8 @@
 .doc_tabs {
-  background-color: $blue-dark;
-  border-top: 1px solid darken($banner-grad-lite, 9%);
-  border-bottom: 1px solid darken($grey-dark, 3%);
-  box-shadow: 0 1px 4px -1px darken($grey-dark, 3%);
+  background-color: var(--color-bg-footer);
+  border-top: 1px solid var(--color-border-header-mid);
+  border-bottom: 1px solid var(--color-border-header-bot);
+  box-shadow: 0 1px 4px -1px var(--color-border-header-bot);
   @include clearfix;
 
   ul {
@@ -16,10 +16,10 @@
       a {
         display: block;
         padding: 1em;
-        color: mix($blue-dark, #fff, 50%);
+        color: var(--color-text-link-header);
 
         &:hover {
-          color: #fff;
+          color: var(--color-text-banner);
           text-decoration: none;
         }
       }
@@ -28,9 +28,9 @@
 }
 
 .doc_menu {
-  color: #fff;
+  color: var(--color-text-doc-menu);
   padding-right: 0;
-  background-color: $grey-dark;
+  background-color: var(--color-bg-menu);
 
   .menu {
     font-size: 14px;
@@ -42,12 +42,12 @@
   }
 
   a {
-    color: #fff;
+    color: var(--color-text-doc-menu);
   }
 }
 
 .doc_menu-heading {
-  color: mix(#fff, $grey-dark, 50%);
+  color: var(--color-text-doc-menu-hdr);
   padding: 1em $menu-level-pad;
 }
 
@@ -57,7 +57,7 @@
 
 .doc-header {
   padding-bottom: 2em;
-  border-bottom: 1px solid $doc-line-lite;
+  border-bottom: 1px solid var(--color-border-secondary);
   margin: 4em 0 2em;
 
   h1 {
@@ -78,7 +78,7 @@
 
       li.active {
         a {
-          color: #fff;
+          color: var(--color-text-banner);
           background-color: lighten($blue-dark, 10%);
         }
       }
@@ -126,13 +126,13 @@
       margin-bottom: 1em;
 
       th {
-        border-bottom: 1px solid $doc-line-lite;
+        border-bottom: 1px solid var(--color-border-secondary);
       }
 
       td, th {
         font-size: 14px;
         padding: 1em;
-        border-right: 1px solid $doc-line-lite;
+        border-right: 1px solid var(--color-border-secondary);
         vertical-align: middle;
 
         &:last-child {
@@ -148,7 +148,7 @@
 
       tr:nth-child(even) {
         td {
-          background-color: lighten($grey-dark, 75%);
+          background-color: var(--color-bg-docs-tbl-even);
         }
       }
     }
@@ -156,11 +156,11 @@
 
   .doc-versions {
     padding-bottom: 1em;
-    border-bottom: 1px solid $doc-line-lite;
+    border-bottom: 1px solid var(--color-border-secondary);
     margin-bottom: 1em;
 
     .label, .separator {
-      color: $text-subdued;
+      color: var(--color-text-tertiary);
     }
 
     .active {
@@ -187,7 +187,7 @@
   .doc-content {
     .section-nav {
       font-size: 14px;
-      border-left: 1px solid $doc-line-lite;
+      border-left: 1px solid var(--color-border-secondary);
       width: 25%;
       position: absolute;
       right: 1em;
@@ -213,7 +213,7 @@
   .toc {
     font-size: 14px;
     padding: 0 1em 1em 1em;
-    border-left: 1px solid $doc-line-lite;
+    border-left: 1px solid var(--color-border-secondary);
     margin: 0 0 2em 2em;
     width: 25%;
     position: absolute;

--- a/site/_assets/css/_features.scss
+++ b/site/_assets/css/_features.scss
@@ -1,5 +1,5 @@
 .features {
-  border-top: 1px solid $grey-lite2;
+  border-top: 1px solid var(--color-border-primary);
   padding: 2em 0
 }
 
@@ -7,7 +7,7 @@
   display: flex;
   margin: 1em 0em;
   padding: 1em;
-  background-color: #fff;
+  background-color: var(--color-bg-secondary);
   box-shadow: 0 1px 1px rgba(0,0,0,0.2);
 }
 
@@ -19,5 +19,5 @@
 }
 
 .feature-text {
-  color: $text-subdued;
+  color: var(--color-text-tertiary);
 }

--- a/site/_assets/css/_footer.scss
+++ b/site/_assets/css/_footer.scss
@@ -1,7 +1,7 @@
 
 .site-footer {
   @include banner_grad;
-  color: #fff;
+  color: var(--color-text-banner);
   padding: 1em;
 
   .social_menu, .contact_menu {
@@ -11,7 +11,7 @@
     margin: 1em 0;
 
     a {
-      color: #fff;
+      color: var(--color-text-banner);
       padding: 0 1em;
     }
   }
@@ -25,10 +25,10 @@
 
 .footer-legal {
   font-size: 12px;
-  color: $blue-lite2;
+  color: var(--color-text-footer);
 
   a {
-    color: #fff;
+    color: var(--color-text-banner);
   }
 }
 
@@ -40,7 +40,7 @@
     height: auto;
 
     g#icon-gitter {
-      fill: #fff;
+      fill: var(--color-text-banner);
     }
   }
 }
@@ -74,20 +74,20 @@
     .social_link {
 
       svg {
-        fill: $blue-lite2;
+        fill: var(--color-text-footer);
       }
 
       svg:hover {
-        fill: #fff;
+        fill: var(--color-text-banner);
       }
 
       i.fa {
         font-size: 22px;
-        color: $blue-lite2;
+        color: var(--color-text-footer);
       }
 
       i.fa:hover {
-        color: #fff;
+        color: var(--color-text-banner);
       }
     }
 
@@ -109,7 +109,7 @@
 
   #footer_bottom {
     height: 60px;
-    background-color: $blue-dark;
+    background-color: var(--color-bg-footer);
   }
 
   .footer-legal {

--- a/site/_assets/css/_header.scss
+++ b/site/_assets/css/_header.scss
@@ -41,7 +41,7 @@ $site-header-sm-pad: 10px;
   top: $site-header-sm-pad;
 
   a {
-    color: #fff;
+    color: var(--color-text-banner);
   }
 }
 
@@ -54,7 +54,7 @@ $site-header-sm-pad: 10px;
 
     .brand {
       float: left;
-      color: #fff;
+      color: var(--color-text-banner);
       display: block;
     }
 

--- a/site/_assets/css/_logo.scss
+++ b/site/_assets/css/_logo.scss
@@ -41,12 +41,22 @@
   }
 }
 
-#logos_inverse {
+#logos_standard, #logos_bw, #glyph {
   .logo_example {
-    background-color: $grey-dark;
+    background-color: var(--color-bg-logo-light);
 
     h3 {
-      color: #fff;
+      color: var(--color-text-logo-light);
+    }
+  }
+}
+
+#logos_inverse {
+  .logo_example {
+    background-color: var(--color-bg-logo-dark);
+
+    h3 {
+      color: var(--color-text-logo-dark);
     }
   }
 }

--- a/site/_assets/css/_menu.scss
+++ b/site/_assets/css/_menu.scss
@@ -34,7 +34,7 @@
   }
 
   li.active > a {
-    background-color: lighten($grey-dark, 8%);
+    background-color: var(--color-bg-menu-active);
   }
 
   a {
@@ -42,10 +42,10 @@
     padding: 1em $menu-level-pad;
     line-height: 1.4;
 
-    color: $menu-link-color;
+    color: var(--color-bg-menu-active);
 
     &:hover {
-      background-color: lighten($grey-dark, 10%);
+      background-color: var(--color-bg-menu-hover);
       text-decoration: none;
     }
 
@@ -68,7 +68,7 @@
   // font-weight: bold;
 
   > a {
-    color: #fff;
+    color: var(--color-text-doc-menu);
 
     &:before {
       @include fa_type;

--- a/site/_assets/css/_page.scss
+++ b/site/_assets/css/_page.scss
@@ -1,6 +1,6 @@
 body {
-  background-color: $site-bg;
-  border-top: 3px solid $blue-lite;
+  background-color: var(--color-bg-primary);
+  border-top: 3px solid var(--color-border-header-top);
   display: flex;
   min-height: 100vh;
   flex-direction: column;
@@ -24,6 +24,10 @@ main img {
   @include responsive_img;
 }
 
+hr {
+  border-top-color: var(--color-border-primary);
+}
+
 .gsc-control-cse {
   padding: 0 !important;
   td {
@@ -41,7 +45,7 @@ table.gsc-input {
   margin: 2px 0 0 5px !important;
 }
 
-.gsst_a .gscb_a {color: #292e33 !important} // 
+.gsst_a .gscb_a {color: var(--color-text-secondary) !important}
 
 .gsc-search-button-v2 {
   background: none !important;

--- a/site/_assets/css/_page.scss
+++ b/site/_assets/css/_page.scss
@@ -27,32 +27,3 @@ main img {
 hr {
   border-top-color: var(--color-border-primary);
 }
-
-.gsc-control-cse {
-  padding: 0 !important;
-  td {
-    padding: 0 5px 0 0 !important;
-  }
-  table tr:nth-child(odd) td {
-    background-color: transparent !important;
-  }
-}
-
-table.gsc-input { 
-  background-color: transparent;
-  font-size: 9px !important;
-  height: 28px !important;
-  margin: 2px 0 0 5px !important;
-}
-
-.gsst_a .gscb_a {color: var(--color-text-secondary) !important}
-
-.gsc-search-button-v2 {
-  background: none !important;
-  border: none !important;
-  padding: 6px !important;
-  svg {
-    width: 16px !important;
-    height: 16px !important;
-  }
-}

--- a/site/_assets/css/_partners.scss
+++ b/site/_assets/css/_partners.scss
@@ -1,5 +1,5 @@
 section.partners {
-  border-top: 1px solid $grey-lite2;
+  border-top: 1px solid var(--color-border-primary);
   padding: 3em 0;
 }
 

--- a/site/_assets/css/_partners.scss
+++ b/site/_assets/css/_partners.scss
@@ -20,8 +20,8 @@ section.partners {
   width: 100%;
 
   img {
-    @include grayscale;
-    opacity: 0.8;
+    filter: var(--partner-img-filter);
+    opacity: var(--partner-img-opacity);
   }
 }
 

--- a/site/_assets/css/_platforms.scss
+++ b/site/_assets/css/_platforms.scss
@@ -1,7 +1,7 @@
 .platforms {
   max-width: 100%;
   padding: 2em 0;
-  background-color: #fff;
+  background-color: var(--color-bg-secondary);
 }
 
 .platforms-container {

--- a/site/_assets/css/_post.scss
+++ b/site/_assets/css/_post.scss
@@ -12,7 +12,7 @@
 
 .post-header {
   padding-bottom: 1em;
-  border-bottom: 1px solid $doc-line-lite;
+  border-bottom: 1px solid var(--color-border-secondary);
   margin-bottom: 1em;
 
   h1 {
@@ -23,7 +23,7 @@
 }
 
 .post-meta {
-  color: $text-subdued;
+  color: var(--color-text-tertiary);
 }
 
 .post-tags {
@@ -55,12 +55,12 @@
     margin-bottom: 0;
 
     a {
-      color: $text-black;
+      color: var(--color-text-primary);
       transition: color 0.5s;
     }
 
     a:hover, a:active {
-      color: $blue-lite;
+      color: var(--color-text-link-hover);
       text-decoration: none;
     }
   }
@@ -73,13 +73,13 @@
 @media only screen and (min-width: #{$bp-desk0}) {
   .post_excerpt {
     padding: 0 2em 2em 0;
-    border-bottom: 1px solid lighten($heading-line, 10%);
+    border-bottom: 1px solid var(--color-border-primary);
     margin-bottom: 3em;
   }
 
   .post-header {
     padding: 0 2em 1em 0;
-    border-bottom: 1px solid $doc-line-lite;
+    border-bottom: 1px solid var(--color-border-secondary);
     margin-bottom: 2em;
 
     h1 {

--- a/site/_assets/css/_search.scss
+++ b/site/_assets/css/_search.scss
@@ -1,0 +1,102 @@
+table.gsc-input { 
+  background-color: transparent;
+  font-size: 9px !important;
+  height: 28px !important;
+  margin: 2px 0 0 5px !important;
+}
+
+.gsst_a .gscb_a {color: var(--color-text-secondary) !important}
+
+.gsc-search-button-v2 {
+  background: none !important;
+  border: none !important;
+  padding: 6px !important;
+  svg {
+    width: 16px !important;
+    height: 16px !important;
+  }
+}
+
+input.gsc-input,
+.gsc-input-box,
+.gsc-input-box-hover,
+.gsc-input-box-focus {
+  background: var(--color-bg-secondary) !important;
+  border-color: var(--color-border-secondary) !important;
+}
+
+.gsc-control-cse {
+  padding: 0 !important;
+  td {
+    padding: 0 5px 0 0 !important;
+  }
+  table tr:nth-child(odd) td {
+    background-color: transparent !important;
+  }
+}
+
+.gsc-modal-background-image {
+  background-color: var(--color-bg-overlay) !important;
+}
+
+.gsc-results,
+.gsc-results-wrapper-overlay,
+.gsc-webResult.gsc-result,
+.gsc-results .gsc-imageResult,
+.gsc-control-cse .gsc-option-menu,
+.gsc-cursor-box,
+.gsc-results .gsc-cursor-box .gsc-cursor-page {
+  background-color: var(--color-bg-secondary) !important;
+}
+
+.gsc-selected-option-container {
+  background-color: var(--color-bg-menu) !important;
+  border-color: var(--color-border-primary) !important;
+  color: var(--color-text-primary) !important;
+}
+
+.gsc-option-menu-item-highlighted {
+  background-color: var(--color-bg-tertiary) !important;
+}
+
+.gsc-option-menu-item,
+.gsc-orderby-label {
+  color: var(--color-text-tertiary) !important;
+}
+
+.gsc-option-menu-item-highlighted {
+  color: var(--color-text-primary) !important;
+}
+
+.gsc-above-wrapper-area,
+.gsc-control-cse .gsc-option-menu {
+  border-color: var(--color-border-primary) !important;
+}
+
+.gsc-webResult.gsc-result,
+.gsc-results .gsc-imageResult {
+  border-color: var(--color-bg-secondary) !important;
+}
+
+.gs-webResult div.gs-visibleUrl,
+.gs-webResult.gs-result a.gs-title:link,
+.gs-webResult.gs-result a.gs-title:link b,
+.gs-webResult.gs-result a.gs-title:visited,
+.gs-webResult.gs-result a.gs-title:visited b,
+.gs-imageResult a.gs-title:link,
+.gs-imageResult a.gs-title:link b,
+.gs-imageResult a.gs-title:visited,
+.gs-imageResult a.gs-title:visited b,
+.gsc-results .gsc-cursor-box .gsc-cursor-page,
+.gcsc-find-more-on-google,
+.gs-webResult:not(.gs-no-results-result):not(.gs-error-result) .gs-snippet, .gs-fileFormatType {
+  color: var(--color-text-primary) !important;
+}
+
+.gsc-result-info {
+  color: var(--color-text-tertiary) !important;
+}
+
+.gcsc-find-more-on-google-magnifier {
+  fill: var(--color-text-primary) !important;
+}

--- a/site/_assets/css/_solutions.scss
+++ b/site/_assets/css/_solutions.scss
@@ -15,7 +15,7 @@ $solution_pad: 4em;
 }
 
 .solution-left {
-  background-color: #fff;
+  background-color: var(--color-bg-secondary);
 
   .solution-img {
     margin-right: 1em;
@@ -50,7 +50,7 @@ $solution_pad: 4em;
 
 .solution-text {
   font-size: 12px;
-  color: lighten($text-black, 10%);
+  color: var(--color-text-solution);
 }
 
 @media only screen and (min-width: #{$bp-desk0}) {

--- a/site/_assets/css/_syntax-highlighting.scss
+++ b/site/_assets/css/_syntax-highlighting.scss
@@ -8,10 +8,18 @@
  * Prevents codeblocks from wrapping their content, and allows them to
  * `overflow: auto` as expected.
  */
+
 pre {
-  code {
-    white-space: pre;
-  }
+  background: var(--color-bg-pre);
+  border-color: var(--color-border-code-pre);
+  color: var(--color-text-code-pre);
+
+  code { white-space: pre; }
+}
+
+code {
+  background-color: var(--color-bg-code);
+  color: var(--color-text-code);
 }
 
 // console specific colorings, dark theme
@@ -39,71 +47,83 @@ $console_bg: #222;
 
 
 .highlight {
-    background: #fff;
+  color:      var(--color-text-code-pre);
+  background: var(--color-bg-primary);
 
-    .highlighter-rouge & {
-      background: #eef;
-    }
+	.highlighter-rouge & {
+		background: var(--color-bg-code-pre);
+	}
 
-    .c     { color: #998; font-style: italic } // Comment
-    .err   { color: #a61717; background-color: #e3d2d2 } // Error
-    .k     { font-weight: bold } // Keyword
-    .o     { font-weight: bold } // Operator
-    .cm    { color: #998; font-style: italic } // Comment.Multiline
-    .cp    { color: #999; font-weight: bold } // Comment.Preproc
-    .c1    { color: #998; font-style: italic } // Comment.Single
-    .cs    { color: #999; font-weight: bold; font-style: italic } // Comment.Special
-    .gd    { color: #000; background-color: #fdd } // Generic.Deleted
-    .gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
-    .ge    { font-style: italic } // Generic.Emph
-    .gr    { color: #a00 } // Generic.Error
-    .gh    { color: #999 } // Generic.Heading
-    .gi    { color: #000; background-color: #dfd } // Generic.Inserted
-    .gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
-    .go    { color: #888 } // Generic.Output
-    .gp    { color: #555 } // Generic.Prompt
-    .gs    { font-weight: bold } // Generic.Strong
-    .gu    { color: #aaa } // Generic.Subheading
-    .gt    { color: #a00 } // Generic.Traceback
-    .kc    { font-weight: bold } // Keyword.Constant
-    .kd    { font-weight: bold } // Keyword.Declaration
-    .kp    { font-weight: bold } // Keyword.Pseudo
-    .kr    { font-weight: bold } // Keyword.Reserved
-    .kt    { color: #458; font-weight: bold } // Keyword.Type
-    .m     { color: #099 } // Literal.Number
-    .s     { color: #d14 } // Literal.String
-    .na    { color: #008080 } // Name.Attribute
-    .nb    { color: #0086B3 } // Name.Builtin
-    .nc    { color: #458; font-weight: bold } // Name.Class
-    .no    { color: #008080 } // Name.Constant
-    .ni    { color: #800080 } // Name.Entity
-    .ne    { color: #900; font-weight: bold } // Name.Exception
-    .nf    { color: #900; font-weight: bold } // Name.Function
-    .nn    { color: #555 } // Name.Namespace
-    .nt    { color: #000080 } // Name.Tag
-    .nv    { color: #008080 } // Name.Variable
-    .ow    { font-weight: bold } // Operator.Word
-    .w     { color: #bbb } // Text.Whitespace
-    .mf    { color: #099 } // Literal.Number.Float
-    .mh    { color: #099 } // Literal.Number.Hex
-    .mi    { color: #099 } // Literal.Number.Integer
-    .mo    { color: #099 } // Literal.Number.Oct
-    .sb    { color: #d14 } // Literal.String.Backtick
-    .sc    { color: #d14 } // Literal.String.Char
-    .sd    { color: #d14 } // Literal.String.Doc
-    .s2    { color: #d14 } // Literal.String.Double
-    .se    { color: #d14 } // Literal.String.Escape
-    .sh    { color: #d14 } // Literal.String.Heredoc
-    .si    { color: #d14 } // Literal.String.Interpol
-    .sx    { color: #d14 } // Literal.String.Other
-    .sr    { color: #009926 } // Literal.String.Regex
-    .s1    { color: #d14 } // Literal.String.Single
-    .ss    { color: #990073 } // Literal.String.Symbol
-    .bp    { color: #999 } // Name.Builtin.Pseudo
-    .vc    { color: #008080 } // Name.Variable.Class
-    .vg    { color: #008080 } // Name.Variable.Global
-    .vi    { color: #008080 } // Name.Variable.Instance
-    .il    { color: #099 } // Literal.Number.Integer.Long
+	.bp    { color: var(--color-syntax-builtin-p) }                                              // Name.Builtin.Pseudo
+	.c     { color: var(--color-syntax-comment); font-style: italic }                            // Comment
+	.c1    { color: var(--color-syntax-comment); font-style: italic }                            // Comment.Single
+	.cd    { color: var(--color-syntax-comment); font-style: italic; }
+	.ch    { color: var(--color-syntax-comment); font-style: italic; }
+	.cm    { color: var(--color-syntax-comment); font-style: italic }                            // Comment.Multiline
+	.cp    { color: var(--color-syntax-comment-ex); font-weight: bold }                          // Comment.Preproc
+	.cpf   { color: var(--color-syntax-comment); font-style: italic; }
+	.cs    { color: var(--color-syntax-comment-ex); font-weight: bold; font-style: italic }      // Comment.Special
+	.err   { color: var(--color-syntax-error); background-color: var(--color-syntax-error-bg); } // Error
+	.gd    { color: #000000; background-color: #FFDDDD }                                         // Generic.Deleted
+	.gd .x { color: #000000; background-color: #FFAAAA }                                         // Generic.Deleted.Specific
+	.ge    { font-style: italic }                                                                // Generic.Emph
+	.gh    { color: #999999 }                                                                    // Generic.Heading
+	.gi    { color: #000000; background-color: #DDFFDD }                                         // Generic.Inserted
+	.gi .x { color: #000000; background-color: #AAFFAA }                                         // Generic.Inserted.Specific
+	.go    { color: #888888 }                                                                    // Generic.Output
+	.gp    { color: #555555 }                                                                    // Generic.Prompt
+	.gr    { color: #AA0000 }                                                                    // Generic.Error
+	.gs    { font-weight: bold }                                                                 // Generic.Strong
+	.gt    { color: #AA0000 }                                                                    // Generic.Traceback
+	.gu    { color: #AAAAAA }                                                                    // Generic.Subheading
+	.il    { color: var(--color-syntax-number); }                                                // Literal.Number.Integer.Long
+	.k     { color: var(--color-syntax-keyword); font-weight: bold; }                            // Keyword
+	.kc    { color: var(--color-syntax-keyword); font-weight: bold; }                            // Keyword.Constant
+	.kd    { color: var(--color-syntax-keyword); font-weight: bold; }                            // Keyword.Declaration
+	.kn    { color: var(--color-syntax-kn); font-weight: bold; }
+	.kp    { color: var(--color-syntax-keyword); font-weight: bold; }                            // Keyword.Pseudo
+	.kr    { color: var(--color-syntax-keyword); font-weight: bold; }                            // Keyword.Reserved
+	.kt    { color: var(--color-syntax-kt); font-weight: bold; }                                 // Keyword.Type
+	.kv    { color: var(--color-syntax-keyword); font-weight: bold; }
+	.m     { color: var(--color-syntax-number); }
+	.mb    { color: var(--color-syntax-number); }                                                // Literal.Number
+	.mf    { color: var(--color-syntax-number); }
+	.mh    { color: var(--color-syntax-number); }                                                // Literal.Number.Float
+	.mi    { color: var(--color-syntax-number); }                                                // Literal.Number.Hex
+	.mo    { color: var(--color-syntax-number); }                                                // Literal.Number.Integer
+	.mx    { color: var(--color-syntax-number); }                                                // Literal.Number.Oct
+	.na    { color: var(--color-syntax-na); }                                                    // Name.Attribute
+	.nb    { color: var(--color-syntax-nb); }                                                    // Name.Builtin
+	.nc    { color: var(--color-syntax-nc); font-weight: bold; }                                 // Name.Class
+	.nd    { color: var(--color-syntax-nd); font-weight: bold; }
+	.ne    { color: var(--color-syntax-ne); font-weight: bold; }                                 // Name.Exception
+	.nf    { color: var(--color-syntax-ne); font-weight: bold; }                                 // Name.Function
+	.ni    { color: var(--color-syntax-ni); }                                                    // Name.Entity
+	.nl    { color: var(--color-syntax-nl); font-weight: bold; }
+	.nn    { color: var(--color-syntax-nn); }                                                    // Name.Namespace
+	.no    { color: var(--color-syntax-constant); }                                              // Name.Constant
+	.nt    { color: var(--color-syntax-tag); }                                                   // Name.Tag
+	.nv    { color: var(--color-syntax-nv); }                                                    // Name.Variable
+	.o     { color: var(--color-syntax-op); font-weight: bold }                                  // Operator
+	.ow    { color: var(--color-syntax-op); font-weight: bold }                                  // Operator.Word
+	.s     { color: var(--color-syntax-string) }                                                 // Literal.String
+	.s1    { color: var(--color-syntax-string) }                                                 // Literal.String.Single
+	.s2    { color: var(--color-syntax-string) }                                                 // Literal.String.Double
+	.sa    { color: var(--color-syntax-sa); font-weight: bold; }
+	.sb    { color: var(--color-syntax-string) }                                                 // Literal.String.Backtick
+	.sc    { color: var(--color-syntax-string) }                                                 // Literal.String.Char
+	.sd    { color: var(--color-syntax-string) }                                                 // Literal.String.Doc
+	.se    { color: var(--color-syntax-e) }                                                      // Literal.String.Escape
+	.sh    { color: var(--color-syntax-string) }                                                 // Literal.String.Heredoc
+	.si    { color: var(--color-syntax-string) }                                                 // Literal.String.Interpol
+	.sr    { color: var(--color-syntax-sr) }                                                     // Literal.String.Regex
+	.ss    { color: var(--color-syntax-ss) }                                                     // Literal.String.Symbol
+	.sx    { color: var(--color-syntax-string) }                                                 // Literal.String.Other
+	.vc    { color: var(--color-syntax-tag) }                                                    // Name.Variable.Class
+	.vg    { color: var(--color-syntax-tag) }                                                    // Name.Variable.Global
+	.vi    { color: var(--color-syntax-tag) }                                                    // Name.Variable.Instance
+	.vm    { color: var(--color-syntax-vm) }
+	.w     { color: var(--color-syntax-w) }                                                      // Text.Whitespace
 }
 
 .language-console {
@@ -113,8 +133,10 @@ $console_bg: #222;
     background: $console_bg;
   }
 
-  .w  { @include console_color_4_bold; } // Prompt
-  .nc { @include console_color_1_bold; } // Command
+  .c  { @include console_color_0_bold; } // Comment
+	.go { color: #888888; }
   .kv { @include console_color_7_bold; } // Extra args
-  .c  { @include console_color_0_bold; } // comment
+  .nc { @include console_color_1_bold; } // Command
+	.nt { @include console_color_1; }      // Command Argument
+  .w  { @include console_color_3_bold; } // Prompt
 }

--- a/site/_assets/css/_triad.scss
+++ b/site/_assets/css/_triad.scss
@@ -14,7 +14,7 @@
   display: flex;
   align-items: center;
   height: 4em;
-  border-bottom: 1px solid $heading-line;
+  border-bottom: 1px solid var(--color-border-primary);
 }
 
 .triad-col:last-child .triad-item {
@@ -32,8 +32,8 @@
 
 .download {
   padding: 1em 0;
-  border-top: 1px solid $heading-line;
-  border-bottom: 1px solid $heading-line;
+  border-top: 1px solid var(--color-border-primary);
+  border-bottom: 1px solid var(--color-border-primary);
 
   h4 {
     text-align: center;
@@ -50,7 +50,7 @@
     position: relative;
     top: $triad-offset;
 
-    background-color: #fff;
+    background-color: var(--color-bg-secondary);
     box-shadow: 0 1px 3px rgba(0,0,0,0.25);
   }
 
@@ -66,7 +66,7 @@
   .triad-col {
     @include make-md-column(4, $triad-gutter);
 
-    border-right: 1px solid $grey-lite;
+    border-right: 1px solid var(--color-border-primary);
 
     &:last-child {
       border-right: none;

--- a/site/_assets/css/_twbs_overrides.scss
+++ b/site/_assets/css/_twbs_overrides.scss
@@ -1,0 +1,54 @@
+.btn-default {
+  color: var(--color-text-btn);                  // #333
+  background-color: var(--color-bg-btn);         // #fff
+  border-color: var(--color-border-btn);         // #ccc
+
+  &:active,
+  &.active,
+  &:focus,
+  &.focus,
+  &:hover {
+		color: var(--color-text-btn);                // #333
+		background-color: var(--color-bg-btn-hover); // #e6e6e6
+		border-color: var(--color-border-btn-hover); // #adadad
+	}
+
+  &:focus,
+  &.focus {
+    border-color: var(--color-border-btn-active); // #8c8c8c
+  }
+
+  &:active,
+  &.active {
+		background-image: none;
+	}
+
+  &:active:hover,
+  &:active:focus,
+  &:active.focus,
+  &.active:hover,
+  &.active:focus,
+  &.active.focus {
+		color: var(--color-text-btn);                 // #333
+    background-color: var(--color-bg-btn-active); // #d4d4d4
+    border-color: var(--color-border-btn-active); // #8c8c8c
+  }
+}
+
+
+.page-header {
+  border-bottom-color: var(--color-border-primary);
+}
+
+.table-hover > tbody > tr:hover {
+  background-color: var(--color-bg-secondary);
+}
+
+.table-bordered > thead > tr > th,
+.table-bordered > thead > tr > td,
+.table-bordered > tbody > tr > th,
+.table-bordered > tbody > tr > td,
+.table-bordered > tfoot > tr > th,
+.table-bordered > tfoot > tr > td {
+  border-color: var(--color-border-primary);
+}

--- a/site/_assets/css/_type.scss
+++ b/site/_assets/css/_type.scss
@@ -3,15 +3,15 @@
 body {
   font-family: "Open Sans", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
   line-height: 1.4;
-  color: $text-black;
+  color: var(--color-text-primary);
 }
 
 a {
-  color: $link-blue;
+  color: var(--color-text-link);
   padding-bottom: 0.01em;
 
   &:hover {
-    color: lighten($link-blue, 10%);
+    color: var(--color-text-link-hover);
     text-decoration: none;
   }
 
@@ -21,7 +21,7 @@ a {
 }
 
 h1, h2, h3, h4 {
-  color: $grey-dark;
+  color: var(--color-text-secondary);
   font-weight: 500;
   text-rendering: optimizeLegibility;
   font-feature-settings: "kern";
@@ -62,7 +62,7 @@ table {
 }
 
 tr:nth-child(odd) td {
-  background-color: darken($site-bg, 4%);
+  background-color: var(--color-bg-tertiary);
 }
 
 td, th {
@@ -70,7 +70,7 @@ td, th {
 }
 
 th {
-  border-bottom: 1px solid $heading-line;
+  border-bottom: 1px solid var(--color-border-heading);
 }
 
 ul {

--- a/site/_assets/css/main.scss
+++ b/site/_assets/css/main.scss
@@ -51,6 +51,7 @@ $menu-level-pad: 36px;
   "colors",
   "type",
   "page",   // page containers and colors
+  "search",
   "menu",
   "site_nav",
   "off_canvas",

--- a/site/_assets/css/main.scss
+++ b/site/_assets/css/main.scss
@@ -7,6 +7,7 @@ $font-size-base: 16px;
 
 @import "font-awesome";
 @import "twbs_custom";
+@import "twbs_overrides";
 
 // Undo Bootstrap pixel font-size
 // http://fvsch.com/code/css-locks/#toc-2d

--- a/site/_assets/css/themes/_dark.scss
+++ b/site/_assets/css/themes/_dark.scss
@@ -78,5 +78,8 @@
   --color-syntax-var:        #F8F8F2;
   --color-syntax-vm:         #F8F8F2;
   --color-syntax-w:          #F8F8F2;
+
+  --partner-img-filter:      invert(100%) contrast(.5) saturate(2) brightness(1.5) grayscale(100%);
+  --partner-img-opacity:     0.6;
 }
 }

--- a/site/_assets/css/themes/_dark.scss
+++ b/site/_assets/css/themes/_dark.scss
@@ -11,6 +11,7 @@
   --color-bg-menu:           #061D2D;
   --color-bg-menu-active:    #113044;
   --color-bg-menu-hover:     #152A37;
+  --color-bg-overlay:        #010D14;
   --color-bg-pre:            #010D14;
   --color-bg-code:           #010D14;
   --color-bg-code-pre:       #010D14;

--- a/site/_assets/css/themes/_dark.scss
+++ b/site/_assets/css/themes/_dark.scss
@@ -3,6 +3,9 @@
   --color-bg-primary:        #021420;
   --color-bg-secondary:      #031826;
   --color-bg-tertiary:       #061D2D;
+  --color-bg-btn:            #061D2D;
+  --color-bg-btn-hover:      #152A37;
+  --color-bg-btn-active:     #010D14;
   --color-bg-docs-tbl-even:  #082032;
   --color-bg-header:         ;
   --color-bg-footer:         #063452;
@@ -19,6 +22,9 @@
   --color-border-primary:    #193344;
   --color-border-secondary:  #0D1F2B;
   --color-border-tertiary:   #0D1F2B;
+  --color-border-btn:        #193344;
+  --color-border-btn-hover:  #193344;
+  --color-border-btn-active: #18394E;
   --color-border-header-top: #00a6e6;
   --color-border-header-mid: #094e7a;
   --color-border-header-bot: #22262b;
@@ -28,6 +34,7 @@
   --color-text-primary:      #F9F9F9;
   --color-text-secondary:    #FFFFFF;
   --color-text-tertiary:     #AAAAAA;
+  --color-text-btn:          #F9F9F9;
   --color-text-banner:       #FFFFFF;
   --color-text-banner-2:     #ABDAF9;
   --color-text-doc-menu:     #FFFFFF;

--- a/site/_assets/css/themes/_dark.scss
+++ b/site/_assets/css/themes/_dark.scss
@@ -1,0 +1,74 @@
+@mixin dark_theme($selector: ":root") {
+#{$selector} {
+  --color-bg-primary:        #021420;
+  --color-bg-secondary:      #031826;
+  --color-bg-tertiary:       #061D2D;
+  --color-bg-docs-tbl-even:  #082032;
+  --color-bg-header:         ;
+  --color-bg-footer:         #063452;
+  --color-bg-logo-dark:      #061D2D;
+  --color-bg-logo-light:     #EFEFEF;
+  --color-bg-menu:           #061D2D;
+  --color-bg-menu-active:    #113044;
+  --color-bg-menu-hover:     #152A37;
+  --color-bg-pre:            #010D14;
+  --color-bg-code:           #010D14;
+  --color-bg-code-pre:       #010D14;
+
+  --color-border-primary:    #193344;
+  --color-border-secondary:  #0D1F2B;
+  --color-border-tertiary:   #0D1F2B;
+  --color-border-header-top: #00a6e6;
+  --color-border-header-mid: #094e7a;
+  --color-border-header-bot: #22262b;
+  --color-border-heading:    #193344;
+  --color-border-code-pre:   #0D1F2B;
+
+  --color-text-primary:      #F9F9F9;
+  --color-text-secondary:    #FFFFFF;
+  --color-text-tertiary:     #AAAAAA;
+  --color-text-banner:       #FFFFFF;
+  --color-text-banner-2:     #ABDAF9;
+  --color-text-doc-menu:     #FFFFFF;
+  --color-text-doc-menu-hdr: #949799;
+  --color-text-footer:       #78c4f6;
+  --color-text-link:         #00A6E6;
+  --color-text-link-hover:   #0490CE;
+  --color-text-link-header:  #839AA9;
+  --color-text-logo-dark:    #FFFFFF;
+  --color-text-logo-light:   #292E33;
+  --color-text-solution:     #D2D2D2;
+  --color-text-code:         #C7254E;
+  --color-text-code-pre:     #F8F8F2;
+
+  --color-syntax-builtin-p:  #F8F8F2;
+  --color-syntax-comment:    #75715E;
+  --color-syntax-comment-ex: #75715E;
+  --color-syntax-constant:   #66D9EF;
+  --color-syntax-error:      #960050;
+  --color-syntax-error-bg:   #1E0010;
+  --color-syntax-keyword:    #66D9EF;
+  --color-syntax-kn:         #F92672;
+  --color-syntax-kt:         #66D9EF;
+  --color-syntax-number:     #AE81FF;
+  --color-syntax-na:         #A6E22E;
+  --color-syntax-nb:         #F8F8F2;
+  --color-syntax-nc:         #A6E22E;
+  --color-syntax-nd:         #A6E22E;
+  --color-syntax-ne:         #A6E22E;
+  --color-syntax-ni:         #F8F8F2;
+  --color-syntax-nl:         #F8F8F2;
+  --color-syntax-nn:         #F8F8F2;
+  --color-syntax-nv:         #F8F8F2;
+  --color-syntax-op:         #F92672;
+  --color-syntax-string:     #E6DB74;
+  --color-syntax-sa:         #66D9EF;
+  --color-syntax-se:         #AE81FF;
+  --color-syntax-sr:         #E6DB74;
+  --color-syntax-ss:         #E6DB74;
+  --color-syntax-tag:        #F92672;
+  --color-syntax-var:        #F8F8F2;
+  --color-syntax-vm:         #F8F8F2;
+  --color-syntax-w:          #F8F8F2;
+}
+}

--- a/site/_assets/css/themes/_light.scss
+++ b/site/_assets/css/themes/_light.scss
@@ -3,6 +3,9 @@
   --color-bg-primary:        #F9F9F9; // $site-bg
   --color-bg-secondary:      #FFFFFF;
   --color-bg-tertiary:       #EFEFEF; // darken($site-bg, 4%)
+  --color-bg-btn:            #FFFFFF;
+  --color-bg-btn-hover:      #E6E6E6;
+  --color-bg-btn-active:     #d4d4d4;
   --color-bg-docs-tbl-even:  #EBEDEF;
   --color-bg-header:         ;
   --color-bg-footer:         #063452; // $blue-dark
@@ -19,6 +22,9 @@
   --color-border-primary:    #EBEDEF; // lighten($heading-line, 10%) (repaces $grey-lite && $grey-lite2)
   --color-border-secondary:  #DDE1E4; // $doc-line-lite
   --color-border-tertiary:   #CFD4D8; // $heading-line
+  --color-border-btn:        #CCCCCC;
+  --color-border-btn-hover:  #CFD4D8;
+  --color-border-btn-active: #8c8c8c;
   --color-border-header-top: #00a6e6; // $blue-lite
   --color-border-header-mid: #094e7a;
   --color-border-header-bot: #22262b;
@@ -28,6 +34,7 @@
   --color-text-primary:      #444444; // $text-black
   --color-text-secondary:    #292E33; // $grey-dark
   --color-text-tertiary:     #7a7a7a; // $text-subdued (replaces "lighten($text-black, 10%)")
+  --color-text-btn:          #333333;
   --color-text-banner:       #FFFFFF; // (no var)
   --color-text-banner-2:     #ABDAF9; // $blue-white
   --color-text-doc-menu:     #FFFFFF; // (no var)

--- a/site/_assets/css/themes/_light.scss
+++ b/site/_assets/css/themes/_light.scss
@@ -11,6 +11,7 @@
   --color-bg-menu:           #061D2D;
   --color-bg-menu-active:    #113044; // lighten($grey-dark, 8%)
   --color-bg-menu-hover:     #152A37;
+  --color-bg-overlay:        #FFFFFF;
   --color-bg-pre:            #F5F5F5;
   --color-bg-code:           #F9F2F4;
   --color-bg-code-pre:       #EEEEFF;

--- a/site/_assets/css/themes/_light.scss
+++ b/site/_assets/css/themes/_light.scss
@@ -78,5 +78,8 @@
   --color-syntax-var:        #008080;
   --color-syntax-vm:         #444444;
   --color-syntax-w:          #BBBBBB;
+
+  --partner-img-filter:      grayscale(100%);
+  --partner-img-opacity:     0.8;
 }
 }

--- a/site/_assets/css/themes/_light.scss
+++ b/site/_assets/css/themes/_light.scss
@@ -1,0 +1,74 @@
+@mixin light_theme($selector: ":root") {
+#{$selector} {
+  --color-bg-primary:        #F9F9F9; // $site-bg
+  --color-bg-secondary:      #FFFFFF;
+  --color-bg-tertiary:       #EFEFEF; // darken($site-bg, 4%)
+  --color-bg-docs-tbl-even:  #EBEDEF;
+  --color-bg-header:         ;
+  --color-bg-footer:         #063452; // $blue-dark
+  --color-bg-logo-dark:      #061D2D;
+  --color-bg-logo-light:     #EFEFEF;
+  --color-bg-menu:           #061D2D;
+  --color-bg-menu-active:    #113044; // lighten($grey-dark, 8%)
+  --color-bg-menu-hover:     #152A37;
+  --color-bg-pre:            #F5F5F5;
+  --color-bg-code:           #F9F2F4;
+  --color-bg-code-pre:       #EEEEFF;
+
+  --color-border-primary:    #EBEDEF; // lighten($heading-line, 10%) (repaces $grey-lite && $grey-lite2)
+  --color-border-secondary:  #DDE1E4; // $doc-line-lite
+  --color-border-tertiary:   #CFD4D8; // $heading-line
+  --color-border-header-top: #00a6e6; // $blue-lite
+  --color-border-header-mid: #094e7a;
+  --color-border-header-bot: #22262b;
+  --color-border-heading:    #CFD4D8; // lighten($grey-dark, 65%);
+  --color-border-code-pre:   #CCCCCC;
+
+  --color-text-primary:      #444444; // $text-black
+  --color-text-secondary:    #292E33; // $grey-dark
+  --color-text-tertiary:     #7a7a7a; // $text-subdued (replaces "lighten($text-black, 10%)")
+  --color-text-banner:       #FFFFFF; // (no var)
+  --color-text-banner-2:     #ABDAF9; // $blue-white
+  --color-text-doc-menu:     #FFFFFF; // (no var)
+  --color-text-doc-menu-hdr: #949799; // mix(#fff, $grey-dark, 50%)
+  --color-text-footer:       #78c4f6; // $blue-lite2
+  --color-text-link:         #036D9C; // $link-blue
+  --color-text-link-hover:   #0490CE; // lighten($link-blue, 10%)
+  --color-text-link-header:  #839aa9; // mix($blue-dark, #fff, 50%)
+  --color-text-logo-dark:    #292E33;
+  --color-text-logo-light:   #FFFFFF;
+  --color-text-solution:     #5E5E5E;
+  --color-text-code:         #C7254E;
+  --color-text-code-pre:     #444444;
+
+  --color-syntax-builtin-p:  #999999;
+  --color-syntax-comment:    #999988;
+  --color-syntax-comment-ex: #999999;
+  --color-syntax-constant:   #008080;
+  --color-syntax-error:      #A61717;
+  --color-syntax-error-bg:   #E3D2D2;
+  --color-syntax-keyword:    #444444;
+  --color-syntax-kn:         #444444;
+  --color-syntax-kt:         #445588;
+  --color-syntax-number:     #009999;
+  --color-syntax-na:         #008080;
+  --color-syntax-nb:         #0086B3;
+  --color-syntax-nc:         #445588;
+  --color-syntax-nd:         #444444;
+  --color-syntax-ne:         #990000;
+  --color-syntax-ni:         #800080;
+  --color-syntax-nl:         #444444;
+  --color-syntax-nn:         #555555;
+  --color-syntax-nv:         #008080;
+  --color-syntax-op:         #444444;
+  --color-syntax-string:     #DD1144;
+  --color-syntax-sa:         #DD1144;
+  --color-syntax-se:         #DD1144;
+  --color-syntax-sr:         #009926;
+  --color-syntax-ss:         #990073;
+  --color-syntax-tag:        #000080;
+  --color-syntax-var:        #008080;
+  --color-syntax-vm:         #444444;
+  --color-syntax-w:          #BBBBBB;
+}
+}

--- a/site/community.md
+++ b/site/community.md
@@ -38,8 +38,8 @@ ManageIQ is open source and open for contributions. There are many ways to get i
   <div class="col-md-6">
     <h3>Discuss</h3>
     <p>Join the active ManageIQ community on <a href="http://talk.manageiq.org/">ManageIQ Talk forum</a> with your questions and discussions, or chat with us anytime on <a href="https://gitter.im/ManageIQ/manageiq">Gitter</a> (sign in with your GitHub account).</p>
-    <p><button class="js-gitter-toggle-chat-button" data-gitter-toggle-chat-state="true">Open Chat</button>
-    <button class="js-gitter-toggle-chat-button" data-gitter-toggle-chat-state="false">Close Chat</button></p>
+    <p><button class="btn btn-default js-gitter-toggle-chat-button" data-gitter-toggle-chat-state="true">Open Chat</button>
+    <button class="btn btn-default js-gitter-toggle-chat-button" data-gitter-toggle-chat-state="false">Close Chat</button></p>
     <br />
     <p>Check out the <a href="/blog/">ManageIQ blog</a> and comment on the latest community news.</p>
 


### PR DESCRIPTION
Adds two 2 themes to `manageiq.org`:

- Light (default/current)
- Dark

Currently just uses browser/OS preference to select a theme.


TODO
----

- [x] Fix table hovering
- [x] Fix `pre`/`code` blocks in API docs
- [x] Fix bg/text colors for `/logos`
- [x] Fix `.btn-default`
- [x] Fix search results
- [x] Fix community Gitter buttons

### In followup...

- Add a theme switcher that uses local storage to save settings
- Add fix landing page icons


Screenshots
-----------

### Light

<img width="1226" alt="Screen Shot 2021-09-02 at 8 50 15 PM" src="https://user-images.githubusercontent.com/314014/131939544-592108ea-9ada-44b8-991a-b36248d3e448.png">
<img width="1226" alt="Screen Shot 2021-09-02 at 8 50 26 PM" src="https://user-images.githubusercontent.com/314014/131939631-01b9ffba-8a6d-4a43-935c-93e31247fc5d.png">
<img width="1226" alt="Screen Shot 2021-09-02 at 8 58 42 PM" src="https://user-images.githubusercontent.com/314014/131939559-e9480af7-811a-40a3-8c04-3542f6861608.png">
<img width="1226" alt="Screen Shot 2021-09-02 at 8 51 15 PM" src="https://user-images.githubusercontent.com/314014/131939556-af5224e9-7e64-4775-99a4-2d03f1eccf42.png">


### Dark

<img width="1226" alt="Screen Shot 2021-09-02 at 8 49 14 PM" src="https://user-images.githubusercontent.com/314014/131939715-07881c19-e9b0-4c9c-861e-6886b662e042.png">
<img width="1226" alt="Screen Shot 2021-09-02 at 8 50 33 PM" src="https://user-images.githubusercontent.com/314014/131939720-e48bfa96-511e-46e0-a9f1-2179bf325031.png">
<img width="1226" alt="Screen Shot 2021-09-02 at 8 51 06 PM" src="https://user-images.githubusercontent.com/314014/131939722-b16397e2-6be1-4e01-977c-121c113fc66a.png">
<img width="1226" alt="Screen Shot 2021-09-02 at 8 58 48 PM" src="https://user-images.githubusercontent.com/314014/131939725-8a5a4a43-5404-4730-a3ed-568ac140b3ec.png">
