### PR TITLE
[_dark.scss] Use light blue for light logos

### DIFF
--- a/site/_assets/css/themes/_dark.scss
+++ b/site/_assets/css/themes/_dark.scss
@@ -10,7 +10,7 @@
   --color-bg-header:         ;
   --color-bg-footer:         #063452;
   --color-bg-logo-dark:      #061D2D;
-  --color-bg-logo-light:     #EFEFEF;
+  --color-bg-logo-light:     #0c69a5;
   --color-bg-menu:           #061D2D;
   --color-bg-menu-active:    #113044;
   --color-bg-menu-hover:     #152A37;
@@ -44,7 +44,7 @@
   --color-text-link-hover:   #0490CE;
   --color-text-link-header:  #839AA9;
   --color-text-logo-dark:    #FFFFFF;
-  --color-text-logo-light:   #292E33;
+  --color-text-logo-light:   #FFFFFF;
   --color-text-page:         #00A6E6;
   --color-text-page-hover:   #0490CE;
   --color-text-solution:     #D2D2D2;


### PR DESCRIPTION
This gives less of a stark contrast when viewing /logos with the Dark theme, as it isn't as harsh as the default white is.

### Before

### After