### PR TITLE
Add _labels.scss

### DIFF
--- a/site/_assets/css/_labels.scss
+++ b/site/_assets/css/_labels.scss
@@ -1,0 +1,15 @@
+/* /docs/guides/labels specific styles */
+
+main[data-url="/docs/guides/labels"] {
+  td img {
+    height: 20px;
+    width: 100px;
+    max-width: max-content;
+  }
+
+  td code, td img {
+    display: block;
+    margin-bottom: 5px;
+    line-height: 16px;
+  }
+}

--- a/site/_assets/css/main.scss
+++ b/site/_assets/css/main.scss
@@ -72,6 +72,7 @@ $menu-level-pad: 36px;
 
 // Docs
 @import "docs";
+@import "labels";
 
 // Blog
 @import "blog";


### PR DESCRIPTION
Adds styles to that label page that can allow removing the need for `</br>` tags in the markdown (which don't even render properly in some processors).


### Before

<img width="1419" alt="Screen Shot 2021-09-22 at 5 04 17 PM" src="https://user-images.githubusercontent.com/314014/134428302-b6da04a2-a33e-4c37-9a5a-373fa4a40f0a.png">


### After

<img width="1410" alt="Screen Shot 2021-09-22 at 5 04 27 PM" src="https://user-images.githubusercontent.com/314014/134428314-de8fc8df-8612-4ba7-9ad3-87a1233150da.png">


Links
-----

- Merge with https://github.com/ManageIQ/guides/pull/471