### PR TITLE
Add theme switcher

### DIFF
--- a/site/_assets/css/_colors.scss
+++ b/site/_assets/css/_colors.scss
@@ -55,8 +55,8 @@ $glphy_img: url("/assets/images/logo/banner-glyph.svg") 173% 50% no-repeat;
 @include light_theme;
 
 @media (prefers-color-scheme: dark) {
-	@include light_theme($selector: ".light-theme");
 	@include dark_theme($selector: ":root, .dark-theme");
+	@include light_theme($selector: ".light-theme");
 }
 
 @media (prefers-color-scheme: light) {

--- a/site/_assets/css/_colors.scss
+++ b/site/_assets/css/_colors.scss
@@ -51,6 +51,7 @@ $glphy_img: url("/assets/images/logo/banner-glyph.svg") 173% 50% no-repeat;
 
 @import "themes/light";
 @import "themes/dark";
+@import "themes/toggle";
 
 @include light_theme;
 

--- a/site/_assets/css/_page.scss
+++ b/site/_assets/css/_page.scss
@@ -4,6 +4,7 @@ body {
   display: flex;
   min-height: 100vh;
   flex-direction: column;
+  transition: background-color 300ms ease 0ms;
 }
 
 main {

--- a/site/_assets/css/_site_nav.scss
+++ b/site/_assets/css/_site_nav.scss
@@ -33,10 +33,11 @@
         margin-right: none;
       }
 
-      a {
+      a, button {
         padding: 0.5em 1em;
         border-radius: 10px;
         border-bottom: none;
+        line-height: 1.4;
       }
     }
   }

--- a/site/_assets/css/_site_nav.scss
+++ b/site/_assets/css/_site_nav.scss
@@ -17,7 +17,7 @@
   a {
     display: block;
     padding: 1em;
-    color: #fff;
+    color: var(--color-text-site-nav);
     border-bottom: 1px solid rgba(255,255,255,0.2);
 
     @include link_background_hover;

--- a/site/_assets/css/themes/_dark.scss
+++ b/site/_assets/css/themes/_dark.scss
@@ -90,5 +90,7 @@
   --partner-img-filter:      invert(100%) contrast(.5) saturate(2) brightness(1.5) grayscale(100%);
   --partner-img-opacity:     0.6;
   --platforms-vcloud-bright: 3;
+
+  .theme-toggle::before { content: ""; }
 }
 }

--- a/site/_assets/css/themes/_dark.scss
+++ b/site/_assets/css/themes/_dark.scss
@@ -52,6 +52,7 @@
   --color-text-logo-light:   #292E33;
   --color-text-page:         #00A6E6;
   --color-text-page-hover:   #0490CE;
+  --color-text-site-nav:     #FFFFFF;
   --color-text-solution:     #D2D2D2;
   --color-text-code:         #C7254E;
   --color-text-code-pre:     #F8F8F2;

--- a/site/_assets/css/themes/_light.scss
+++ b/site/_assets/css/themes/_light.scss
@@ -52,6 +52,7 @@
   --color-text-logo-light:   #FFFFFF;
   --color-text-page:         #337ab7;
   --color-text-page-hover:   #23527c;
+  --color-text-site-nav:     #FFFFFF;
   --color-text-solution:     #5E5E5E;
   --color-text-code:         #C7254E;
   --color-text-code-pre:     #444444;

--- a/site/_assets/css/themes/_light.scss
+++ b/site/_assets/css/themes/_light.scss
@@ -90,5 +90,7 @@
   --partner-img-filter:      grayscale(100%);
   --partner-img-opacity:     0.8;
   --platforms-vcloud-bright: 0;
+
+  .theme-toggle::before { content: ""; }
 }
 }

--- a/site/_assets/css/themes/_toggle.scss
+++ b/site/_assets/css/themes/_toggle.scss
@@ -1,0 +1,7 @@
+:root, .light-theme, .dark-theme {
+  .theme-toggle {
+    color:      var(--color-text-site-nav);
+    border:     none;
+    background: none;
+  }
+}

--- a/site/_includes/head.html
+++ b/site/_includes/head.html
@@ -8,6 +8,19 @@
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <meta property="og:image" content="http://manageiq.org/assets/images/logo/manageiq-logo-blue.png" />
 
+  <script>
+    stored_theme = localStorage.getItem('miq-theme');
+    theme        = stored_theme && JSON.parse(localStorage.getItem('miq-theme'));
+
+    if (theme === "light-theme") {
+      document.querySelector('html').classList.add("light-theme");
+    }
+
+    if (theme === "dark-theme") {
+      document.querySelector('html').classList.add("dark-theme");
+    }
+  </script>
+
   {% css main %}
   <link rel="canonical" href="{{ page.canonical_url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">

--- a/site/_includes/site_nav.html
+++ b/site/_includes/site_nav.html
@@ -11,4 +11,7 @@
   <li {% if page.url contains "/blog/" %}class="active"{% endif %}>
     <a href="/blog/">Blog</a>
   </li>
+  <li>
+    <button class="fa theme-toggle" data-toggle-theme></i>
+  </li>
 </ul>

--- a/site/assets/js/_theme.coffee
+++ b/site/assets/js/_theme.coffee
@@ -1,0 +1,33 @@
+miq.light_theme      = "light-theme"
+miq.dark_theme       = "dark-theme"
+miq.storage_key     = "miq-theme"
+miq.button_selector = "[data-toggle-theme]"
+miq.html_doc        = miq.select("html")
+miq.theme_button    = miq.select(miq.button_selector)
+
+miq.set_theme = (was, now) ->
+  miq.html_doc.classList.add(now)
+  miq.html_doc.classList.remove(was)
+  localStorage.setItem(miq.storage_key, JSON.stringify(now))
+
+miq.handle_button_click = ->
+  # get the current theme from localStorage
+  current_theme = localStorage.getItem(miq.storage_key)
+
+  # If the current theme and its light theme then set it to dark theme else if
+  # its dark then set it to light
+  if current_theme
+    if (JSON.parse(current_theme) == miq.light_theme)
+      miq.set_theme(miq.light_theme, miq.dark_theme)
+    else
+      miq.set_theme(miq.dark_theme, miq.light_theme)
+
+  else
+    # if localStorage is not defined then we want to use whatever the media
+    # color-scheme is to switch it to the opposite
+    if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches)
+      miq.set_theme(miq.dark_theme, miq.light_theme)
+    else
+      miq.set_theme(miq.light_theme, miq.dark_theme)
+
+miq.theme_button.addEventListener("click", miq.handle_button_click)

--- a/site/assets/js/main.coffee
+++ b/site/assets/js/main.coffee
@@ -12,3 +12,4 @@ miq.select = (selector = "body") ->
 {% include_relative _site_menu.coffee %}
 {% include_relative _doc_menu.coffee %}
 {% include_relative _lightbox.coffee %}
+{% include_relative _theme.coffee %}


### PR DESCRIPTION
Allows switching between dark/light themes, regardless of OS preference.

In this case, the theme will first be determined by the OS/Browser theme preference.  Then, when the toggle button is switched, it will override that value with a css class ('.light-theme' or '.dark-theme') on the top level `<html>` tag.  This with then switch the theme to the one preferred by the user, and save that preference in local storage.

When the page is reloaded or a new page is accessed, it will check that value first before trying to render the page.  This is why some raw JS code is required in `_head.html` since it is used to render the theme prior to the full page load.

Font awesome icons for "sun" and "moon" are used for the toggle switch, but they don't use the built in CSS classes since it is one less thing that needs to be written into the JS code.  


### Light Theme

![miq_org_toggle_on_light_theme](https://user-images.githubusercontent.com/314014/135928698-170fc720-349c-40c2-9d8c-97c7444942de.png)


### Dark Theme

![miq_org_toggle_on_dark_theme](https://user-images.githubusercontent.com/314014/135928714-823eb648-0377-43d2-9797-34bbd616776a.png)


Links
-----

* Previous efforts:
  - https://github.com/ManageIQ/manageiq.org/pull/1010
  - https://github.com/ManageIQ/manageiq.org/pull/1015
  - https://github.com/ManageIQ/manageiq.org/pull/1019
  - https://github.com/ManageIQ/manageiq.org/pull/1020
* References:
  - https://uxdesign.cc/if-only-you-knew-the-power-of-dark-mode-f2fed46fb908
  - https://jec.fyi/blog/supporting-dark-mode