### PR TITLE
Fix build failures after downgrade from Rails 5.2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "activesupport", :require => false
+gem "activesupport", ">= 5.2.7", :require => false
 gem "bootstrap-sass", "~> 3.x"
 gem "font-awesome-sass", "~> 4.x"
 gem "jekyll", "~> 3.x"


### PR DESCRIPTION
It seems that a more recent version of bundler caused the version of Rails to downgrade from 5.2.7 to 5.2.6.3, which is when the failures started.