### PR TITLE
Fix broken link

### DIFF
--- a/site/docs/get-started/kubernetes.md
+++ b/site/docs/get-started/kubernetes.md
@@ -54,6 +54,6 @@ oc patch deployment httpd -p '{"spec":{"template":{"spec":{"containers":[{"name"
 
 ManageIQ is now up and running at the host provided in the APPLICATION_DOMAIN parameter.
 
-For more detailed installation instructions see the guide in the [manageiq-pods repository](https://github.com/ManageIQ/manageiq-pods/blob/{{release.tag}}/README.md).
+For more detailed installation instructions see the guide in the [manageiq-pods repository](https://github.com/ManageIQ/manageiq-pods/blob/{{release.tag}}/master/README.md).
 
 Next step is to perform some [basic configuration](/docs/get-started/basic-configuration).


### PR DESCRIPTION
2nd from bottom line of page, the link to `manageiq-pods repository` displays a 404 error: https://www.manageiq.org/docs/get-started/kubernetes.html

![image](https://user-images.githubusercontent.com/20925310/165321433-723c518a-2ec9-481b-b745-264e9b3a8d20.png)
