### PR TITLE
Fix issue when prerelease doesn't exist

### DIFF
--- a/site/docs/get-started/kubernetes.md
+++ b/site/docs/get-started/kubernetes.md
@@ -6,7 +6,7 @@ title: Easy Install With Kubernetes
 You can get ManageIQ up and running quickly on a Kubernetes
 cluster using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)
 
-{% assign release = site.data.releases["prerelease"] %}
+{% assign release = site.data.releases["stable"] %}
 
 Ensure minikube is installed and configured with enough resources:
 


### PR DESCRIPTION
This page was built when kubernetes was still in beta, but now that it's
been shipped we should be pointing to the stable release. This fixes the
`git checkout` line as well as the link to the `README.md`
documentation.

Replaces #1089 

@chessbyte Please review.
cc @hobbert