### PR TITLE
Fix broken link

### DIFF
--- a/site/docs/get-started/add-a-provider.md
+++ b/site/docs/get-started/add-a-provider.md
@@ -9,8 +9,7 @@ Many other platforms are available including Amazon Web Services, VMware
 vSphere and OpenStack.
 
 Capabilities between providers can be different
-and evolve with time, so don’t forget to check the [support options
-document](https://manageiq.org/docs/reference/latest/doc-Managing_Providers/miq/)
+and evolve with time, so don’t forget to check the [support options document](https://manageiq.org/docs/reference/latest/capabilities_matrix/index)
 
 ### Create a Google Cloud Platform account (if needed)
 


### PR DESCRIPTION
Link to "support options document" (2nd link on page) is broken.

![image](https://user-images.githubusercontent.com/20925310/165362348-fe0716f4-1f78-4f2c-934f-9a14b0ed4bb6.png)
