### PR TITLE
Upgrade Ruby to 2.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.5'
+          ruby-version: '2.7'
           bundler-cache: true
       - name: Build
         run: bundle exec exe/miq build all --trace


### PR DESCRIPTION
There is an issue in CI with building libv8 that has been fixed in a
newer rubygems.  Instead of just upgrading Ruby gems, we might as well
update Ruby itself.