### PR TITLE
Fix issue where certain ENV vars are not propagated

### DIFF
--- a/lib/miq/executor.rb
+++ b/lib/miq/executor.rb
@@ -51,7 +51,8 @@ module Miq
     def run_cmd_with_bundle_env(cmd, clean)
       success =
         if clean || (cmd =~ /cd\ /)
-          Bundler.clean_system(cmd)
+          env = ENV.to_h.slice("BUNDLE_WITHOUT", "MIQ_DEBUG", "MIQ_ENV")
+          Bundler.clean_system(env, cmd)
         else
           system(cmd)
         end


### PR DESCRIPTION
This issue was caused by https://github.com/ManageIQ/manageiq.org/pull/1079, but I'm not sure why it happened later and not in that original PR.