### PR TITLE
Remove v2v documentation

### DIFF
--- a/site/_data/menus/api_menu.yml
+++ b/site/_data/menus/api_menu.yml
@@ -51,8 +51,6 @@
     path: "/docs/reference/latest/api/reference/conditions.html"
   - title: Configuration Script Source Management
     path: "/docs/reference/latest/api/reference/configuration_script_sources.html"
-  - title: Conversion Hosts
-    path: "/docs/reference/latest/api/reference/conversion_hosts.html"
   - title: Custom Actions
     path: "/docs/reference/latest/api/reference/custom_actions.html"
   - title: Custom Attributes
@@ -121,8 +119,6 @@
     path: "/docs/reference/latest/api/reference/tasks.html"
   - title: Tenant Management
     path: "/docs/reference/latest/api/reference/tenants.html"
-  - title: Transformation Mappings
-    path: "/docs/reference/latest/api/reference/transformation_mappings.html"
   - title: User Management
     path: "/docs/reference/latest/api/reference/users.html"
   - title: VM Management


### PR DESCRIPTION
This was removed as part of https://github.com/ManageIQ/manageiq-api/pull/1085
and the large project to remove v2v:
https://github.com/ManageIQ/manageiq/issues/21379

Related to github.com/ManageIQ/manageiq-documentation/pull/1681