### PR TITLE
Cleanup some blog tags that aren't useful

### DIFF
--- a/site/_posts/2013-11-20-inspectxml-dump-objects-as-xml.md
+++ b/site/_posts/2013-11-20-inspectxml-dump-objects-as-xml.md
@@ -1,7 +1,7 @@
 ---
 title: inspectXML – Dump objects as XML
 date: 2013-11-20
-tags: external operations cloudforms vmware rhev kvm cluster vm datastore XML
+tags: operations cloudforms automate XML
 author: John Hardy
 ---
 

--- a/site/_posts/2017-11-24-implementing-continuous-integration-for-cloudforms-using-git-and-travis.md
+++ b/site/_posts/2017-11-24-implementing-continuous-integration-for-cloudforms-using-git-and-travis.md
@@ -1,7 +1,7 @@
 ---     
 title: Implementing Continuous Integration for CloudForms using Git and Travis
 date: 2017-11-24
-tags: cloudforms management operations show
+tags: cloudforms management operations
 author: Victor Estival Lopez
 ---
 

--- a/site/_posts/2018-01-12-my-first-contribution-to-manageiq.md
+++ b/site/_posts/2018-01-12-my-first-contribution-to-manageiq.md
@@ -1,7 +1,7 @@
 ---     
 title: My First Contribution to ManageIQ
 date: 2018-01-12
-tags: cloudforms operations github manageiq pull-request vmware
+tags: cloudforms operations github collaboration pull-request vmware
 author: Imaanpreet Kaur
 ---
 

--- a/site/_posts/2018-02-13-automating-instance-provisioning-with-cloudforms-and-ansible-tower-video.md
+++ b/site/_posts/2018-02-13-automating-instance-provisioning-with-cloudforms-and-ansible-tower-video.md
@@ -1,7 +1,7 @@
 ---     
 title: Automating Instance Provisioning with CloudForms and Ansible Tower (Video) 
 date: 2018-02-13
-tags: ansible cloudforms provisioning automation azure microsoft self-service servicenow tower workflows
+tags: ansible ansible-tower cloudforms provisioning automate azure microsoft self-service servicenow workflows
 author: Justin Burine
 ---
 

--- a/site/_posts/2018-02-23-cloudforms-database-high-availability-explained.md
+++ b/site/_posts/2018-02-23-cloudforms-database-high-availability-explained.md
@@ -1,7 +1,7 @@
 ---
 title: CloudForms Database High Availability Explained 
 date: 2018-02-23
-tags: cloudforms internal
+tags: cloudforms HA
 author: Giovanni Fontana
 ---
 

--- a/site/_posts/2018-03-22-cloudforms-on-aws-part-1-series.md
+++ b/site/_posts/2018-03-22-cloudforms-on-aws-part-1-series.md
@@ -1,7 +1,7 @@
 ---
 title: CloudForms on AWS Part 1 (Series) 
 date: 2018-03-22
-tags: aws cloudforms series
+tags: aws cloudforms
 author: Laurent Domb
 ---
 

--- a/site/_posts/2018-03-27-cloudforms-in-aws-part2.md
+++ b/site/_posts/2018-03-27-cloudforms-in-aws-part2.md
@@ -1,7 +1,7 @@
 ---
 title: CloudForms in AWS part 2 
 date: 2018-03-27
-tags: aws cloudforms series
+tags: aws cloudforms
 author: Laurent Domb
 ---
 

--- a/site/_posts/2018-04-02-cloudforms-in-aws-part4.md
+++ b/site/_posts/2018-04-02-cloudforms-in-aws-part4.md
@@ -1,7 +1,7 @@
 ---     
 title: CloudForms in AWS part 4 
 date: 2018-04-02
-tags: ansible aws cloudforms series
+tags: ansible aws cloudforms
 author: Laurent Domb
 ---
 

--- a/site/_posts/2018-04-09-cloudforms-in-aws-part5-authenitcation.md
+++ b/site/_posts/2018-04-09-cloudforms-in-aws-part5-authenitcation.md
@@ -1,7 +1,7 @@
 ---
 title: CloudForms in AWS part 5 (authentication)
 date: 2018-04-09
-tags: aws cloudforms series
+tags: aws cloudforms
 author: Laurent Domb
 ---
 

--- a/site/_posts/2020-06-26-cloudforms-blog-is-moving-to-manageiq.md
+++ b/site/_posts/2020-06-26-cloudforms-blog-is-moving-to-manageiq.md
@@ -1,7 +1,7 @@
 ---
 title: CloudForms blog is moving to ManageIQ 
 date: 2020-06-26
-tags: none
+tags: cloudforms
 author: digitalkeri
 ---
 


### PR DESCRIPTION
These blog tags clutter up the list of tags and generally only point to
one article, but aren't really useful for various reasons.

@jrafanie Please review.