### PR TITLE
Fix issue where a newer jekyll-assets is breaking the build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "activesupport", ">= 5.2.7", :require => false
 gem "bootstrap-sass", "~> 3.x"
 gem "font-awesome-sass", "~> 4.x"
 gem "jekyll", "~> 3.x"
-gem "jekyll-assets"
+gem "jekyll-assets", "< 3" # jekyll-assets 3.0.12 brings in sprockets 4 which has a bug: See https://github.com/envygeeks/jekyll-assets/pull/636
 gem "jekyll-coffeescript"
 gem "jekyll-paginate"
 gem "jekyll-sitemap"


### PR DESCRIPTION
bundler 2.4's new resolver is resolving jekyll-assets to a newer version
(3.0.12; was 2.4.0), which, in turn, is bringing in a major version bump
of sprockets (4.0.3, was 3.7.2). This version of sprockets has a
different interface in the find_directory_manifest method which is
overridden by jekyll-assets. See https://github.com/envygeeks/jekyll-assets/pull/636

This can be seeing in the error during the build:

```
bundler: failed to load command: jekyll (/home/runner/work/manageiq.org/manageiq.org/vendor/bundle/ruby/2.7.0/bin/jekyll)
/home/runner/work/manageiq.org/manageiq.org/vendor/bundle/ruby/2.7.0/gems/jekyll-assets-3.0.12/lib/jekyll/assets/manifest.rb:58:in `find_directory_manifest': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from /home/runner/work/manageiq.org/manageiq.org/vendor/bundle/ruby/2.7.0/gems/sprockets-4.0.3/lib/sprockets/manifest.rb:56:in `initialize'
	from /home/runner/work/manageiq.org/manageiq.org/vendor/bundle/ruby/2.7.0/gems/jekyll-assets-3.0.12/lib/jekyll/assets/manifest.rb:29:in `initialize'
	from /home/runner/work/manageiq.org/manageiq.org/vendor/bundle/ruby/2.7.0/gems/jekyll-assets-3.0.12/lib/jekyll/assets/env.rb:48:in `new'
	from /home/runner/work/manageiq.org/manageiq.org/vendor/bundle/ruby/2.7.0/gems/jekyll-assets-3.0.12/lib/jekyll/assets/env.rb:48:in `initialize'
	from /home/runner/work/manageiq.org/manageiq.org/vendor/bundle/ruby/2.7.0/gems/jekyll-assets-3.0.12/lib/jekyll/assets.rb:24:in `new'
	from /home/runner/work/manageiq.org/manageiq.org/vendor/bundle/ruby/2.7.0/gems/jekyll-assets-3.0.12/lib/jekyll/assets.rb:24:in `block in <top (required)>'
	from /home/runner/work/manageiq.org/manageiq.org/vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.2/lib/jekyll/hooks.rb:103:in `block in trigger'
```

This commit locks down jekyll-assdets to `< 3` in order to not bring in
the newer sprockets.