### PR TITLE
Allow passing MIQ_REF_MASTER to build a different branch for docs

### DIFF
--- a/lib/miq/ref_docs.rb
+++ b/lib/miq/ref_docs.rb
@@ -20,6 +20,9 @@ module Miq
       # Where do the docs live?
       @repo     = ENV["MIQ_REF_REPO"] || "https://github.com/ManageIQ/manageiq-documentation.git"
 
+      # What branch should we build as the master branch (useful for local development)
+      @master_branch = ENV["MIQ_REF_MASTER"] || "master"
+
       # What branches to copy?
       @branches = Miq.doc_branches
 
@@ -83,7 +86,7 @@ module Miq
         logger.info "Building ref docs for #{branch}"
         shell [
           "cd #{tmp_dir}",
-          "git checkout #{branch}",
+          "git checkout #{branch == "master" ? @master_branch : branch}",
           "#{bundler} exec rake clean build"
         ].join(" && ")
 


### PR DESCRIPTION
This is mostly for development where you make changes in a branch in manageiq-documentation, but then it builds master (and not your branch) anyway. This ENV var allows you to pretend you development branch is "master".

Example usage:

```
MIQ_REF_REPO=~/dev/manageiq-documentation MIQ_REF_MASTER=bullet_list_journalctl MIQ_ENV=production BUNDLE_WITHOUT=test:development bundle exec exe/miq build all
```

@agrare Please review.
