### PR TITLE
Fix issue where theme switcher in the footer didn't work

### DIFF
--- a/site/assets/js/_theme.coffee
+++ b/site/assets/js/_theme.coffee
@@ -1,9 +1,9 @@
-miq.light_theme      = "light-theme"
-miq.dark_theme       = "dark-theme"
+miq.light_theme     = "light-theme"
+miq.dark_theme      = "dark-theme"
 miq.storage_key     = "miq-theme"
 miq.button_selector = "[data-toggle-theme]"
 miq.html_doc        = miq.select("html")
-miq.theme_button    = miq.select(miq.button_selector)
+miq.theme_buttons   = miq.selectAll(miq.button_selector)
 
 miq.set_theme = (was, now) ->
   miq.html_doc.classList.add(now)
@@ -30,4 +30,5 @@ miq.handle_button_click = ->
     else
       miq.set_theme(miq.light_theme, miq.dark_theme)
 
-miq.theme_button.addEventListener("click", miq.handle_button_click)
+for button in miq.theme_buttons
+  button.addEventListener("click", miq.handle_button_click)

--- a/site/assets/js/main.coffee
+++ b/site/assets/js/main.coffee
@@ -8,6 +8,9 @@
 miq.select = (selector = "body") ->
   document.querySelector(selector)
 
+miq.selectAll = (selector = "body") ->
+  document.querySelectorAll(selector)
+
 {% include_relative _header.coffee %}
 {% include_relative _site_menu.coffee %}
 {% include_relative _doc_menu.coffee %}


### PR DESCRIPTION
Before this commit, the code that attaches the event listener only looked at the first instance in the header, but misses the footer. After this commit it looks at all instances.

![ManageIQ](https://github.com/ManageIQ/manageiq.org/assets/52120/98193104-603e-42a4-b8f2-7e9f9b7b613d)
