### PR TITLE
Add configuration script payloads API to API menu

### DIFF
--- a/site/_data/menus/api_menu.yml
+++ b/site/_data/menus/api_menu.yml
@@ -49,6 +49,8 @@
     path: "/docs/reference/latest/api/reference/cloud_volumes.html"
   - title: Conditions
     path: "/docs/reference/latest/api/reference/conditions.html"
+  - title: Configuration Script Payloads
+    path: "/docs/reference/latest/api/reference/configuration_script_payloads.html"
   - title: Configuration Script Source Management
     path: "/docs/reference/latest/api/reference/configuration_script_sources.html"
   - title: Custom Actions


### PR DESCRIPTION
This change is for adding the Configuration Script Payloads API documentation to the API menu navigation. This API document was added in a separate PR to the manageiq-documentation repo.