### PR TITLE
Fix tags doesn't support commas

### DIFF
--- a/site/_posts/2017-09-29-miqldap-to-sssd.md
+++ b/site/_posts/2017-09-29-miqldap-to-sssd.md
@@ -4,7 +4,7 @@ author: jvlcek
 date: 2017-09-29
 comments: true
 published: true
-tags: ldap, tutorials
+tags: ldap tutorials
 ---
 
 How does one use the *miqldap_to_sssd* conversion tool?

--- a/site/_posts/2018-01-31-troubleshooting-auth.md
+++ b/site/_posts/2018-01-31-troubleshooting-auth.md
@@ -4,7 +4,7 @@ author: jvlcek
 date: 2018-01-31
 comments: true
 published: true
-tags: ldap, tutorials
+tags: ldap tutorials
 ---
 
 The goal of this blog post is to provide a basic understanding of:

--- a/site/_posts/2018-02-01-auth-overview.md
+++ b/site/_posts/2018-02-01-auth-overview.md
@@ -4,7 +4,7 @@ author: jvlcek
 date: 2018-02-01
 comments: true
 published: true
-tags: ldap, tutorials
+tags: ldap tutorials
 ---
 
 This blog post provides a high level overview of the ways ManageIQ Authentication can be configured.


### PR DESCRIPTION
@jrafanie Please review.  I forgot that this doesn't expect `, `, so the tag on the website right now is literally `ldap,` 😑 